### PR TITLE
fix: prevent deadlock by removing nested semaphore acquisition, add regression test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "pytest-asyncio>=0.21",
     "black>=22.0",
     "flake8>=5.0",
     "mypy>=1.0",
@@ -170,6 +171,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "-ra -q --strict-markers --strict-config"
+asyncio_mode = "auto"
 testpaths = ["tests"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/src/devdox_ai_locust/hybrid_loctus_generator.py
+++ b/src/devdox_ai_locust/hybrid_loctus_generator.py
@@ -762,10 +762,9 @@ class HybridLocustGenerator:
 
         for attempt in range(self.MAX_RETRIES):  # Retry logic
             try:
-                async with self._api_semaphore:
-                    content = await self._make_api_call(messages)
-                    if content:
-                        return content
+                content = await self._make_api_call(messages)
+                if content:
+                    return content
 
             except asyncio.TimeoutError:
                 logger.warning(f"AI service timeout on attempt {attempt + 1}")

--- a/tests/src/devdox_ai_locust/test_ai_deadlock_nested_semaphore.py
+++ b/tests/src/devdox_ai_locust/test_ai_deadlock_nested_semaphore.py
@@ -1,0 +1,160 @@
+"""
+This module was created to reproduce the issue faced in `DEV-49-critical-prevent-ai-enhancement-deadlock-nested-semaphore-acquisition`.
+Then after fixing the issue, we check via the test whether the issue will still happen
+
+"""
+
+
+import asyncio
+import types
+import pytest
+
+from devdox_ai_locust.hybrid_loctus_generator import HybridLocustGenerator
+
+class _FakeMessage:
+    """
+    `HybridLocustGenerator` expects an object like `AsyncTogether` that can do:
+    `self.ai_client.chat.completions.create(...)` and returns a response shaped like:
+    `response.choices[0].message.content`
+    
+    This class mimics `response.choices[0].message.content`:
+    - Represents the `message` object inside a completion choice.
+    - Only contains `.content`.
+    """
+    def __init__(self, content: str):
+        self.content = content
+
+
+class _FakeChoice:
+    """
+    `HybridLocustGenerator` expects an object like `AsyncTogether` that can do:
+    `self.ai_client.chat.completions.create(...)` and returns a response shaped like:
+    `response.choices[0].message.content`
+
+    This class mimics `response.choices[0].message`:
+        - Represents one “choice” returned by the AI.
+        - Stores a message.
+    """
+    def __init__(self, content: str):
+        self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    """
+    `HybridLocustGenerator` expects an object like `AsyncTogether` that can do:
+    `self.ai_client.chat.completions.create(...)` and returns a response shaped like:
+    `response.choices[0].message.content`
+
+    This class mimics `response.choices`:
+    - Represents the full response object.
+    - Has `.choices` list, with one choice.
+    """
+    def __init__(self, content: str):
+        self.choices = [_FakeChoice(content)]
+
+
+class FakeAsyncTogether:
+    
+    """
+        This is a fake replacement for Together’s real client.
+        
+    """
+    
+    class _Completions:
+        def create(self, **kwargs):
+            """
+                In the real Together client, create(...) returns something awaitable.
+                Here, we make it return an async coroutine.
+            """
+            async def _coro():
+                """When awaited, it returns a fake response containing <code>print('ok')</code>."""
+                # Return something that the generator can parse.
+                return _FakeResponse("<code>print('ok')</code>")
+            
+            return _coro()
+    
+    class _Chat:
+        """
+        Mimics `client.chat.completions`
+        """
+        def __init__(self):
+            self.completions = FakeAsyncTogether._Completions()
+    
+    def __init__(self):
+        """the generator can call: ai_client.chat.completions.create(...) normally."""
+        self.chat = FakeAsyncTogether._Chat()
+
+
+class TestAiDeadlockNestedSemaphore:
+    @pytest.mark.asyncio
+    # @pytest.mark.xfail(
+    #     reason="Known deadlock before fix: nested semaphore acquisition in _call_ai_service -> _make_api_call",
+    #     strict=True,
+    # )
+    async def test_ai_calls_can_deadlock_due_to_nested_semaphore_acquisition(self):
+        """
+        EXPECTED (after fix):
+          - Both concurrent calls complete quickly.
+          - Each returns cleaned Python code text.
+    
+        CURRENT (before fix):
+          - This test will HANG unless we wrap it in a timeout.
+          - The hang is a deadlock:
+              * each task acquires the semaphore once in _call_ai_service
+              * then each task tries to acquire it again in _make_api_call
+              * since all permits are already held, nobody can proceed
+              * no exception is raised from your code, it just waits forever till operations time out
+        """
+        # ===================================================
+        # ARRANGE
+        # ===================================================
+        
+        # create the generator using the fake AI client so no real network calls happen
+        gen = HybridLocustGenerator(ai_client=FakeAsyncTogether())
+    
+        # Make the deadlock easier to trigger deterministically with 2 concurrent tasks.
+        # We set semaphore capacity to 2 because we will run 2 concurrent calls.
+        # Deadlock happens when concurrency "fills the semaphore" at the outer level.
+        # In production code it’s Semaphore(5), the same deadlock occurs when you hit 5 concurrent calls.
+        gen._api_semaphore = asyncio.Semaphore(2)
+    
+        # Barrier to force both tasks to:
+        #   1) acquire the outer semaphore in _call_ai_service
+        #   2) arrive at _make_api_call
+        #   3) only then proceed together into the inner acquisition attempt
+        barrier = asyncio.Event()
+        arrived_lock = asyncio.Lock()
+        arrived = 0
+    
+        original_make_api_call = gen._make_api_call
+    
+        async def patched_make_api_call(self, messages):
+            nonlocal arrived
+            async with arrived_lock:
+                arrived += 1
+                if arrived == 2:
+                    barrier.set()
+    
+            # Both tasks pause here, *while still holding the outer semaphore permit*.
+            # Once they are released, they will both attempt the inner "async with semaphore"
+            # inside original _make_api_call, when no permits remain -> deadlock.
+            await barrier.wait()
+            return await original_make_api_call(messages)
+    
+        gen._make_api_call = types.MethodType(patched_make_api_call, gen)
+    
+        async def run_two_calls():
+            results = await asyncio.gather(
+                gen._call_ai_service("prompt-1"),
+                gen._call_ai_service("prompt-2"),
+            )
+            # After the fix, it is expected that both with return code (not hang).
+            assert len(results) == 2
+            assert all("print('ok')" in r or 'print("ok")' in r for r in results)
+
+        # ===================================================
+        # ACT & ASSERT
+        # ===================================================
+        
+        # If deadlock happens, this timeout fires and the test fails (xfail for now).
+        await asyncio.wait_for(run_two_calls(), timeout=0.5)

--- a/tests/utils/test_file_creation.py
+++ b/tests/utils/test_file_creation.py
@@ -1,6 +1,7 @@
 """
 Tests for file_creation utility module
 """
+import os
 
 import pytest
 import asyncio
@@ -425,22 +426,27 @@ class TestSafeFileCreatorIntegration:
         # Check that all files exist
         for i in range(10):
             assert (staging_dir / f"file_{i}.py").exists()
-
+    
     @pytest.mark.asyncio
     async def test_error_handling(self, temp_dir):
-        """Test error handling in file operations."""
-        creator = SafeFileCreator()
+        
+        
+        if os.geteuid() == 0:
+            # The test depends on normal permissions rules, but root bypasses those rules, this
+            # skips it when permission is root
+            pytest.skip(
+                "PermissionError behavior is not reliable when tests run as root."
+            )
 
-        # Test with read-only directory
+        creator = SafeFileCreator()
         readonly_dir = temp_dir / "readonly"
         readonly_dir.mkdir()
-        readonly_dir.chmod(0o444)  # Read-only
+        readonly_dir.chmod(0o555)  # traverse OK, no write (for non-root)
 
         try:
             with pytest.raises(PermissionError):
                 await creator.create_temp_file("test.py", "print('test')", readonly_dir)
         finally:
-            # Restore permissions for cleanup
             readonly_dir.chmod(0o755)
 
     def test_custom_config_integration(self):


### PR DESCRIPTION
# Meta

Related Jira Task: https://montyholding.atlassian.net/browse/DEV-49

# What this commit trying to fix?

**The semaphore is like a room with limited chairs**

- A semaphore with value 2 means: only 2 people can sit in the room at once.

- If 2 people are already sitting, a 3rd person must wait outside until someone leaves.

## What the code accidentally does

Inside `_call_ai_service()` you do something like:

- Step 1: “enter the room” (acquire semaphore)

- Step 2: call _make_api_call()

But `_make_api_call()` ALSO does:

- Step 3: “enter the room again” (acquire the same semaphore again)

So each AI request does:

> enter room -> while still inside, tries to enter room again

That is double-entering the same room.

## Why deadlock happens

If you have exactly 2 AI calls running:

1. Call A enters room (seat 1 taken)
2. Call B enters room (seat 2 taken)

Now room is full. Then:

3. Call A tries to enter again (but room is full → waits)
4. Call B tries to enter again (room is full → waits)

But they can’t leave the room because they are stuck waiting to enter again. So both are stuck forever. That is the deadlock.

# Changelog

## 1) Regression test

Added a regression test that allows me to produce the deadlock issue, the test’s job is to:

1. Force exactly two AI calls to run at the same time
2. Force both of them to reach the “try to enter again” point at the same time
3. Confirm they get stuck (deadlock) by seeing that the function never finishes
4. Use a timeout to convert “never finishes” into a test signal: TimeoutError happened

So the test is basically If the code hangs forever, that proves the deadlock exists.

## 2) Applied the fix

### Target behavior

You want one permit acquisition per actual API request (per “network call”), not two.
So the semaphore should be acquired only at the lowest level that actually performs the request.

In your current design, that lowest level is `_make_api_call()`. Therefore:

- Keep async with self._api_semaphore: in _make_api_call()
- Remove async with self._api_semaphore: from _call_ai_service()

This eliminates the nested acquisition and therefore the deadlock.


#### code change

##### Before (current problematic pattern)

`_call_ai_service()` acquires the semaphore, then calls `_make_api_call()` which acquires the same semaphore again.

##### After (fixed)

`_call_ai_service()` does retries/backoff without holding the semaphore.

`_make_api_call()` is the only place that holds the semaphore, strictly around the awaited API call.



## What you should see before and after the fix

### Before fix (bug exists)
- Two calls enter the semaphore room.
- Both try to enter the semaphore room again.
- They freeze.
- wait_for(..., timeout=0.5) triggers TimeoutError.
- Test is marked xfail, so pytest says: “Yep, we expected this.”

### After fix

- The two calls finish normally.
- No timeout happens.
- Because the test is still marked xfail strict, pytest screams “XPASS” (unexpected pass).
- You remove xfail.
- Now it becomes a normal test that ensures deadlock never comes back.
