### PR TITLE
We are generating tasks, then accidentally wiping them from `locustfile.py`

### DIFF
--- a/src/devdox_ai_locust/locust_generator.py
+++ b/src/devdox_ai_locust/locust_generator.py
@@ -279,7 +279,7 @@ class LocustTestGenerator:
 
             # Properly indent task methods for class inclusion
             indented_task_methods = self._indent_methods(task_methods, indent_level=1)
-            indented_task_methods = ""
+
             # Generate the complete file content
             return self._build_locustfile_template(
                 api_info=api_info,


### PR DESCRIPTION
# Meta:
Related Jira: 
- https://montyholding.atlassian.net/browse/DEV-51

Related pull request:
- https://github.com/montymobile1/devdox-ai-locust/pull/25


# Description:

removed the `indented_task_methods = ""` because the generator constructs task methods for each endpoint (the code that actually hits endpoints). Then at the end we are erasing them by setting the string to empty.

It looks like leftover debugging or an unfinished refactor. So, removed this:
```
indented_task_methods = ""
```