### PR TITLE
Dev 48 fix critical generator issues before new cli command making the generator output deterministic and cross platform safe

### DIFF
--- a/src/devdox_ai_locust/cli.py
+++ b/src/devdox_ai_locust/cli.py
@@ -137,15 +137,30 @@ def _show_run_instructions(
     )
 
 
+def _is_url(source: str) -> bool:
+    """Check if the source is a URL or a file path"""
+    source = source.strip()
+    return source.startswith(('http://', 'https://'))
+
+
 async def _process_api_schema(
-    swagger_url: str, verbose: bool
+    swagger_source: str, verbose: bool
 ) -> Tuple[Dict[str, Any], List[Endpoint], Dict[str, Any]]:
-    """Fetch and parse API schema"""
-    source_request = SwaggerProcessingRequest(swagger_url=swagger_url)
+    """Fetch and parse API schema from URL or file path"""
+
+    # Determine if source is URL or file path
+    is_url = _is_url(swagger_source)
+
+    # Create appropriate request based on source type
+    if is_url:
+        source_request = SwaggerProcessingRequest(swagger_url=swagger_source)
+        source_type = "URL"
+    else:
+        source_request = SwaggerProcessingRequest(swagger_path=swagger_source)
+        source_type = "file"
+
     api_schema = None
-    with console.status(
-        f"[bold green]Fetching API schema from {'URL' if swagger_url.startswith(('http://', 'https://')) else 'file'}..."
-    ):
+    with console.status(f"[bold green]Fetching API schema from {source_type}..."):
         try:
             async with asyncio.timeout(30):
                 api_schema = await get_api_schema(source_request)
@@ -156,6 +171,9 @@ async def _process_api_schema(
 
         except asyncio.TimeoutError:
             console.print("[red]✗[/red] Timeout while fetching API schema")
+            sys.exit(1)
+        except FileNotFoundError as e:
+            console.print(f"[red]✗[/red] File not found: {e}")
             sys.exit(1)
         except Exception as e:
             console.print(f"[red]✗[/red] Error fetching API schema: {e}")

--- a/src/devdox_ai_locust/cli.py
+++ b/src/devdox_ai_locust/cli.py
@@ -239,6 +239,15 @@ async def _generate_and_create_tests(
         if test_directories:
             workflows_dir = output_dir / "workflows"
             workflows_dir.mkdir(exist_ok=True)
+
+            # Create __init__.py to make workflows a proper Python package
+            init_file = workflows_dir / "__init__.py"
+            init_file.write_text(
+                '"""Workflow modules for Locust load testing"""\n',
+                encoding="utf-8"
+            )
+            created_files.append({"filename": "workflows/__init__.py", "path": init_file})
+
             for file_workflow in test_directories:
                 workflow_files = await generator._create_test_files_safely(
                     file_workflow, workflows_dir

--- a/src/devdox_ai_locust/hybrid_loctus_generator.py
+++ b/src/devdox_ai_locust/hybrid_loctus_generator.py
@@ -5,10 +5,11 @@ Combines reliable template-based generation with LLM enhancement for creativity
 and domain-specific optimizations.
 """
 
+import ast
 import re
 import asyncio
 import logging
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Dict, List, Any, Optional, Tuple, Set
 from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 from dataclasses import dataclass
@@ -41,6 +42,214 @@ CRITICAL_FUNCTIONS = {
     "test_data.py": ["generate_json_data", "generate_string", "generate_id"],
     "utils.py": ["validate_response", "log_request"],
 }
+
+
+class SafeCodeMerger:
+    """
+    Safely merges AI-generated code additions into original code.
+
+    This approach:
+    1. ALWAYS keeps the original code intact
+    2. Only ADDS new methods/classes from AI output
+    3. Never replaces or modifies existing code
+    4. Uses AST parsing for safety
+    """
+
+    @staticmethod
+    def get_existing_names(code: str) -> Tuple[Set[str], Set[str], Set[str]]:
+        """
+        Extract existing class names, method names, and function names from code.
+
+        Returns:
+            Tuple of (class_names, method_names, function_names)
+        """
+        class_names: Set[str] = set()
+        method_names: Set[str] = set()
+        function_names: Set[str] = set()
+
+        try:
+            tree = ast.parse(code)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef):
+                    class_names.add(node.name)
+                    # Get methods within the class
+                    for item in node.body:
+                        if isinstance(item, ast.FunctionDef):
+                            method_names.add(f"{node.name}.{item.name}")
+                elif isinstance(node, ast.FunctionDef):
+                    # Top-level function
+                    if not any(isinstance(parent, ast.ClassDef) for parent in ast.walk(tree)):
+                        function_names.add(node.name)
+        except SyntaxError:
+            logger.warning("Failed to parse code with AST, falling back to regex")
+            # Fallback to regex
+            class_names = set(re.findall(r'class\s+(\w+)\s*[:\(]', code))
+            function_names = set(re.findall(r'^def\s+(\w+)\s*\(', code, re.MULTILINE))
+
+        return class_names, method_names, function_names
+
+    @staticmethod
+    def extract_new_methods_only(original_code: str, ai_code: str, target_class: str = None) -> str:
+        """
+        Extract ONLY new methods from AI code that don't exist in original.
+
+        This is a conservative approach that:
+        1. Identifies methods in AI output
+        2. Filters out any that already exist in original
+        3. Returns only the truly new additions
+
+        Handles both:
+        - Full class definitions from AI
+        - Standalone method definitions (method-only output)
+        """
+        if not ai_code or not ai_code.strip():
+            return ""
+
+        orig_classes, orig_methods, orig_functions = SafeCodeMerger.get_existing_names(original_code)
+
+        # Get all existing method names (without class prefix) for comparison
+        existing_method_names = set()
+        for method in orig_methods:
+            if "." in method:
+                existing_method_names.add(method.split(".")[-1])
+        existing_method_names.update(orig_functions)
+
+        try:
+            ai_tree = ast.parse(ai_code)
+        except SyntaxError:
+            logger.warning("AI code has syntax errors, trying to extract methods via regex")
+            # Fallback: extract method definitions via regex
+            return SafeCodeMerger._extract_methods_regex(ai_code, existing_method_names)
+
+        new_methods = []
+
+        for node in ast.iter_child_nodes(ai_tree):
+            if isinstance(node, ast.ClassDef):
+                # Check if this is an existing class we should add methods to
+                if node.name in orig_classes:
+                    # Extract only new methods from this class
+                    for item in node.body:
+                        if isinstance(item, ast.FunctionDef):
+                            if item.name not in existing_method_names:
+                                try:
+                                    method_source = ast.get_source_segment(ai_code, item)
+                                    if method_source:
+                                        # Ensure proper indentation for class method
+                                        indented = SafeCodeMerger._indent_code(method_source, 4)
+                                        new_methods.append(f"    # AI-added method\n{indented}")
+                                except Exception:
+                                    pass
+
+            elif isinstance(node, ast.FunctionDef):
+                # Standalone method definition (AI returned methods only)
+                if node.name not in existing_method_names:
+                    try:
+                        method_source = ast.get_source_segment(ai_code, node)
+                        if method_source:
+                            # Add indentation for class method
+                            indented = SafeCodeMerger._indent_code(method_source, 4)
+                            new_methods.append(f"    # AI-added method\n{indented}")
+                    except Exception:
+                        pass
+
+        return "\n\n".join(new_methods)
+
+    @staticmethod
+    def _indent_code(code: str, spaces: int) -> str:
+        """Add indentation to code block."""
+        indent = " " * spaces
+        lines = code.split("\n")
+        # Check if already indented
+        if lines and lines[0].startswith(" " * spaces):
+            return code
+        return "\n".join(indent + line if line.strip() else line for line in lines)
+
+    @staticmethod
+    def _extract_methods_regex(ai_code: str, existing_methods: Set[str]) -> str:
+        """Fallback method extraction using regex when AST fails."""
+        # Match method definitions
+        pattern = r'(def\s+(\w+)\s*\([^)]*\).*?(?=\ndef\s|\Z))'
+        matches = re.findall(pattern, ai_code, re.DOTALL)
+
+        new_methods = []
+        for full_match, method_name in matches:
+            if method_name not in existing_methods:
+                indented = SafeCodeMerger._indent_code(full_match.strip(), 4)
+                new_methods.append(f"    # AI-added method\n{indented}")
+
+        return "\n\n".join(new_methods)
+
+    @staticmethod
+    def safe_merge(original_code: str, ai_additions: str, target_class: str = None) -> str:
+        """
+        Safely merge AI additions into original code.
+
+        This method:
+        1. ALWAYS returns the original code as base
+        2. Only appends new methods that don't exist
+        3. Never modifies existing code
+
+        Args:
+            original_code: The original template-generated code (ALWAYS preserved)
+            ai_additions: Code generated by AI (only new parts used)
+            target_class: If specified, add new methods to this class
+
+        Returns:
+            Original code with safe additions appended
+        """
+        if not ai_additions or not ai_additions.strip():
+            logger.info("No AI additions to merge, returning original")
+            return original_code
+
+        # Extract only new methods (handles syntax errors internally)
+        new_methods = SafeCodeMerger.extract_new_methods_only(
+            original_code, ai_additions, target_class
+        )
+
+        if not new_methods:
+            logger.info("No new methods found in AI output, returning original")
+            return original_code
+
+        # Find where to insert new methods (at the end of the target class)
+        if target_class:
+            # Find the class definition and locate the end of the class
+            # Look for the class and find where it ends
+            lines = original_code.split('\n')
+            class_start = -1
+            class_indent = 0
+
+            for i, line in enumerate(lines):
+                if re.match(rf'\s*class\s+{target_class}\s*[\(:]', line):
+                    class_start = i
+                    class_indent = len(line) - len(line.lstrip())
+                    break
+
+            if class_start >= 0:
+                # Find the end of the class (next line with same or less indentation that's not empty)
+                class_end = len(lines)
+                for i in range(class_start + 1, len(lines)):
+                    line = lines[i]
+                    if line.strip() and not line.strip().startswith('#'):
+                        current_indent = len(line) - len(line.lstrip())
+                        if current_indent <= class_indent and not line.strip().startswith('def '):
+                            # Check if this is a new class or module-level code
+                            if re.match(r'\s*(class\s|def\s|if\s+__name__|@|[A-Z_]+\s*=)', line):
+                                class_end = i
+                                break
+
+                # Insert new methods before the class ends
+                new_lines = lines[:class_end]
+                new_lines.append("")
+                new_lines.append(new_methods)
+                new_lines.extend(lines[class_end:])
+
+                merged = '\n'.join(new_lines)
+                logger.info(f"Added new methods to {target_class}")
+                return merged
+
+        # Fallback: append at end of file
+        logger.info("Appending new methods at end of file")
+        return original_code + "\n\n# AI-enhanced additions\n" + new_methods
 
 
 @dataclass
@@ -1189,33 +1398,52 @@ class HybridLocustGenerator:
         original_content: str,
     ) -> str:
         """
-        Safely apply AI enhancement with validation and fallback.
+        Safely apply AI enhancement using additive-only merging.
+
+        This method uses a fundamentally safer approach:
+        1. ALWAYS keep the original code intact as the base
+        2. Extract ONLY new methods from AI output
+        3. Merge new methods into original (never replace)
 
         Args:
             filename: Name of the file
-            enhanced_content: AI-enhanced content (may be None or corrupted)
-            original_content: Original template-generated content
+            enhanced_content: AI-generated content (may be corrupted)
+            original_content: Original template-generated content (ALWAYS preserved)
 
         Returns:
-            The validated content to use (enhanced if valid, original if corrupted)
+            Original code with any valid AI additions safely merged
         """
-        if not enhanced_content:
-            logger.warning(f"AI returned empty content for {filename}, using original")
+        if not enhanced_content or not enhanced_content.strip():
+            logger.info(f"No AI content for {filename}, using original")
             return original_content
 
-        # Validate syntax first
-        if not self._validate_python_code(enhanced_content):
-            logger.error(f"AI returned invalid Python for {filename}, using original")
-            return original_content
+        # Determine target class for this file
+        target_class = None
+        if filename == test_data_file_path:
+            target_class = "TestDataGenerator"
+        elif filename == "utils.py":
+            target_class = "ResponseValidator"  # Primary class to extend
 
-        # Validate critical elements are preserved
-        is_valid, content_to_use, missing = self._validate_critical_elements(
-            filename, enhanced_content, original_content
+        # Use SafeCodeMerger to safely combine original + AI additions
+        merged_content = SafeCodeMerger.safe_merge(
+            original_code=original_content,
+            ai_additions=enhanced_content,
+            target_class=target_class
+        )
+
+        # Final validation: ensure critical elements still exist
+        is_valid, final_content, missing = self._validate_critical_elements(
+            filename, merged_content, original_content
         )
 
         if not is_valid:
-            logger.warning(
-                f"Reverting {filename} to original due to missing: {missing}"
-            )
+            # This should never happen with SafeCodeMerger, but just in case
+            logger.error(f"SafeCodeMerger produced invalid output for {filename}, using original")
+            return original_content
 
-        return content_to_use
+        # Verify syntax of merged content
+        if not self._validate_python_code(final_content):
+            logger.error(f"Merged content has syntax errors for {filename}, using original")
+            return original_content
+
+        return final_content

--- a/src/devdox_ai_locust/hybrid_loctus_generator.py
+++ b/src/devdox_ai_locust/hybrid_loctus_generator.py
@@ -215,7 +215,7 @@ class EnhancementProcessor:
                 base_content=value,
                 test_data_content=base_files.get(test_data_file_path, ""),
                 base_workflow=base_workflow_files,
-                grouped_enpoints=workflow_endpoints_dict,
+                grouped_endpoints=workflow_endpoints_dict,
                 auth_endpoints=auth_endpoints,
                 db_type=db_type,
                 template_path=template_path,
@@ -633,7 +633,7 @@ class HybridLocustGenerator:
         base_content: str,
         test_data_content: str,
         base_workflow: str,
-        grouped_enpoints: Dict[str, List[Endpoint]],
+        grouped_endpoints: Dict[str, List[Endpoint]],
         auth_endpoints: List[Endpoint],
         db_type: str = "",
         template_path: str = workflow_jinja_path,
@@ -643,7 +643,7 @@ class HybridLocustGenerator:
 
             # Render enhanced content
             prompt = template.render(
-                grouped_enpoints=grouped_enpoints,
+                grouped_endpoints=grouped_endpoints,
                 test_data_content=test_data_content,
                 base_workflow=base_workflow,
                 auth_endpoints=auth_endpoints,
@@ -729,30 +729,34 @@ class HybridLocustGenerator:
         ]
 
     async def _make_api_call(self, messages: list[dict]) -> Optional[str]:
-        """Make API call - ONE job"""
-        async with self._api_semaphore:
-            api_call = self.ai_client.chat.completions.create(
-                model=self.ai_config.model,
-                messages=messages,
-                max_tokens=self.ai_config.max_tokens,
-                temperature=self.ai_config.temperature,
-                top_p=0.9,
-                top_k=40,
-                repetition_penalty=1.1,
-            )
+        """
+        Make API call - ONE job.
 
-            # Wait for the API call with timeout
-            response = await asyncio.wait_for(
-                api_call,
-                timeout=self.ai_config.timeout,
+        Note: This method assumes the caller has already acquired _api_semaphore.
+        Do NOT acquire the semaphore here to avoid deadlock.
+        """
+        api_call = self.ai_client.chat.completions.create(
+            model=self.ai_config.model,
+            messages=messages,
+            max_tokens=self.ai_config.max_tokens,
+            temperature=self.ai_config.temperature,
+            top_p=0.9,
+            top_k=40,
+            repetition_penalty=1.1,
+        )
+
+        # Wait for the API call with timeout
+        response = await asyncio.wait_for(
+            api_call,
+            timeout=self.ai_config.timeout,
+        )
+        if response.choices and response.choices[0].message:
+            content = response.choices[0].message.content.strip()
+            # Clean up the response
+            content = self._clean_ai_response(
+                self.extract_code_from_response(content)
             )
-            if response.choices and response.choices[0].message:
-                content = response.choices[0].message.content.strip()
-                # Clean up the response
-                content = self._clean_ai_response(
-                    self.extract_code_from_response(content)
-                )
-                return content
+            return content
 
         return None
 

--- a/src/devdox_ai_locust/hybrid_loctus_generator.py
+++ b/src/devdox_ai_locust/hybrid_loctus_generator.py
@@ -179,7 +179,9 @@ class EnhancementProcessor:
 
         # Enhance all other workflow files
         for workflow_item in directory_files:
-            if workflow_item.get("file_name") == base_workflow_path:
+            # workflow_item is a dict like {"filename.py": "content"}
+            # Skip base_workflow.py as it's already handled above
+            if base_workflow_path in workflow_item:
                 continue
 
             result = await self._process_workflow_item(
@@ -203,7 +205,7 @@ class EnhancementProcessor:
         base_workflow_files: str,
         grouped_endpoints: Dict[str, List[Endpoint]],
         db_type: str = "",
-        template_path: str =workflow_jinja_path,
+        template_path: str = workflow_jinja_path,
     ) -> Dict[str, Any] | None:
         """Enhance a single workflow file"""
         for key, value in workflow_item.items():
@@ -416,7 +418,7 @@ class HybridLocustGenerator:
             return base_files, directory_files
 
         except Exception as e:
-            logger.error(f"Hybrid generation failed line 267 : {e}")
+            logger.error(f"Hybrid generation failed: {e}")
 
             return {}, []
 

--- a/src/devdox_ai_locust/hybrid_loctus_generator.py
+++ b/src/devdox_ai_locust/hybrid_loctus_generator.py
@@ -29,6 +29,19 @@ data_provider_path = "data_provider.py"
 base_workflow_path = "base_workflow.py"
 workflow_jinja_path = "workflow.j2"
 
+# Critical classes that MUST exist in each file after AI enhancement
+# If these are missing, the AI has corrupted the file and we must use the original
+CRITICAL_CLASSES = {
+    "test_data.py": ["TestDataGenerator"],
+    "utils.py": ["ResponseValidator", "RequestLogger", "PerformanceMonitor", "DataManager"],
+}
+
+# Critical functions that MUST exist in each file
+CRITICAL_FUNCTIONS = {
+    "test_data.py": ["generate_json_data", "generate_string", "generate_id"],
+    "utils.py": ["validate_response", "log_request"],
+}
+
 
 @dataclass
 class ErrorClassification:
@@ -241,36 +254,56 @@ class EnhancementProcessor:
     async def process_test_data_enhancement(
         self, base_files: Dict[str, str], endpoints: List[Endpoint], db_type: str = ""
     ) -> Tuple[Dict[str, str], List[str]]:
-        """Process test data enhancement"""
+        """Process test data enhancement with validation and fallback"""
         enhanced_files = {}
         enhancements = []
-        if self.ai_config and self.ai_config.enhance_test_data:
+        original_content = base_files.get(test_data_file_path, "")
+
+        if self.ai_config and self.ai_config.enhance_test_data and original_content:
             enhanced_test_data = await self.locust_generator.enhance_test_data_file(
-                base_files.get(test_data_file_path, ""),
+                original_content,
                 endpoints,
                 db_type,
                 base_files.get(data_provider_path, ""),
                 base_files.get("db_config.py", ""),
                 data_provider_path,
             )
-            if enhanced_test_data:
-                enhanced_files[test_data_file_path] = enhanced_test_data
+            # Use safe enhancement with validation and fallback
+            validated_content = self.locust_generator._safe_enhance_file(
+                test_data_file_path, enhanced_test_data, original_content
+            )
+            enhanced_files[test_data_file_path] = validated_content
+            # Only mark as enhanced if we actually used the AI output
+            if validated_content == enhanced_test_data:
                 enhancements.append("smart_test_data")
+            else:
+                enhancements.append("test_data_fallback_to_original")
+
         return enhanced_files, enhancements
 
     async def process_validation_enhancement(
         self, base_files: Dict[str, str], endpoints: List[Endpoint]
     ) -> Tuple[Dict[str, str], List[str]]:
-        """Process validation enhancement"""
+        """Process validation enhancement with validation and fallback"""
         enhanced_files = {}
         enhancements = []
-        if self.ai_config and self.ai_config.enhance_validation:
+        original_content = base_files.get("utils.py", "")
+
+        if self.ai_config and self.ai_config.enhance_validation and original_content:
             enhanced_validation = await self.locust_generator._enhance_validation(
-                base_files.get("utils.py", ""), endpoints
+                original_content, endpoints
             )
-            if enhanced_validation:
-                enhanced_files["utils.py"] = enhanced_validation
+            # Use safe enhancement with validation and fallback
+            validated_content = self.locust_generator._safe_enhance_file(
+                "utils.py", enhanced_validation, original_content
+            )
+            enhanced_files["utils.py"] = validated_content
+            # Only mark as enhanced if we actually used the AI output
+            if validated_content == enhanced_validation:
                 enhancements.append("advanced_validation")
+            else:
+                enhancements.append("utils_fallback_to_original")
+
         return enhanced_files, enhancements
 
 
@@ -1087,3 +1120,102 @@ class HybridLocustGenerator:
             return True
         except SyntaxError:
             return False
+
+    def _validate_critical_elements(
+        self, filename: str, enhanced_content: str, original_content: str
+    ) -> Tuple[bool, str, List[str]]:
+        """
+        Validate that AI-enhanced content preserves critical classes and functions.
+
+        Args:
+            filename: Name of the file being validated
+            enhanced_content: The AI-enhanced content
+            original_content: The original template-generated content
+
+        Returns:
+            Tuple of (is_valid, content_to_use, list_of_missing_elements)
+        """
+        missing_elements = []
+
+        # Check critical classes
+        if filename in CRITICAL_CLASSES:
+            for class_name in CRITICAL_CLASSES[filename]:
+                # Look for class definition pattern
+                class_pattern = rf"class\s+{class_name}\s*[:\(]"
+                if not re.search(class_pattern, enhanced_content):
+                    missing_elements.append(f"class {class_name}")
+                    logger.warning(
+                        f"AI corrupted {filename}: missing critical class '{class_name}'"
+                    )
+
+        # Check critical functions (only if they exist in original)
+        if filename in CRITICAL_FUNCTIONS:
+            for func_name in CRITICAL_FUNCTIONS[filename]:
+                func_pattern = rf"def\s+{func_name}\s*\("
+                # Only check if the function exists in original
+                if re.search(func_pattern, original_content):
+                    if not re.search(func_pattern, enhanced_content):
+                        missing_elements.append(f"def {func_name}")
+                        logger.warning(
+                            f"AI corrupted {filename}: missing critical function '{func_name}'"
+                        )
+
+        if missing_elements:
+            logger.error(
+                f"AI enhancement corrupted {filename}, missing: {missing_elements}. "
+                f"Falling back to original template code."
+            )
+            return False, original_content, missing_elements
+
+        # Additional validation: enhanced content shouldn't be dramatically smaller
+        original_lines = len(original_content.strip().split("\n"))
+        enhanced_lines = len(enhanced_content.strip().split("\n"))
+
+        # If enhanced is less than 30% of original size, it's likely corrupted
+        if original_lines > 50 and enhanced_lines < original_lines * 0.3:
+            logger.error(
+                f"AI enhancement drastically reduced {filename} "
+                f"({original_lines} -> {enhanced_lines} lines). "
+                f"Falling back to original template code."
+            )
+            return False, original_content, ["content_too_small"]
+
+        return True, enhanced_content, []
+
+    def _safe_enhance_file(
+        self,
+        filename: str,
+        enhanced_content: Optional[str],
+        original_content: str,
+    ) -> str:
+        """
+        Safely apply AI enhancement with validation and fallback.
+
+        Args:
+            filename: Name of the file
+            enhanced_content: AI-enhanced content (may be None or corrupted)
+            original_content: Original template-generated content
+
+        Returns:
+            The validated content to use (enhanced if valid, original if corrupted)
+        """
+        if not enhanced_content:
+            logger.warning(f"AI returned empty content for {filename}, using original")
+            return original_content
+
+        # Validate syntax first
+        if not self._validate_python_code(enhanced_content):
+            logger.error(f"AI returned invalid Python for {filename}, using original")
+            return original_content
+
+        # Validate critical elements are preserved
+        is_valid, content_to_use, missing = self._validate_critical_elements(
+            filename, enhanced_content, original_content
+        )
+
+        if not is_valid:
+            logger.warning(
+                f"Reverting {filename} to original due to missing: {missing}"
+            )
+
+        return content_to_use

--- a/src/devdox_ai_locust/hybrid_loctus_generator.py
+++ b/src/devdox_ai_locust/hybrid_loctus_generator.py
@@ -176,6 +176,14 @@ class EnhancementProcessor:
             if result:
                 base_workflow_content = result["files"].get(base_workflow_path, "")
                 enhancements.extend(result["enhancements"])
+                # Add enhanced base_workflow.py to output
+                enhanced_directory_files.append(result["files"])
+            else:
+                # Enhancement failed, preserve original base_workflow.py
+                enhanced_directory_files.append({base_workflow_path: base_workflow_content})
+        elif base_workflow_content:
+            # include_auth is False but base_workflow.py exists - preserve it
+            enhanced_directory_files.append({base_workflow_path: base_workflow_content})
 
         # Enhance all other workflow files
         for workflow_item in directory_files:

--- a/src/devdox_ai_locust/hybrid_loctus_generator.py
+++ b/src/devdox_ai_locust/hybrid_loctus_generator.py
@@ -253,6 +253,236 @@ class SafeCodeMerger:
 
 
 @dataclass
+class ProtectedSymbol:
+    """A symbol that is protected because other files depend on it."""
+    name: str
+    symbol_type: str  # 'class', 'function', 'method', 'constant'
+    defined_in: str  # file where it's defined
+    used_by: List[str]  # files that import/use it
+    reason: str  # why it's protected
+
+
+class CodebaseAwareness:
+    """
+    Analyzes the generated codebase to understand dependencies between files.
+
+    This creates a "sandbox" for AI enhancement by identifying:
+    1. What symbols (classes, functions) each file exports
+    2. What each file imports from other files
+    3. Which symbols are "protected" (used by other files)
+    4. Which symbols are "free" (can be modified/removed)
+
+    The AI is then given this context so it knows what it MUST preserve.
+    """
+
+    def __init__(self):
+        self.files: Dict[str, str] = {}  # filename -> content
+        self.exports: Dict[str, Set[str]] = {}  # filename -> exported symbols
+        self.imports: Dict[str, Dict[str, Set[str]]] = {}  # filename -> {source_file: symbols}
+        self.protected: Dict[str, List[ProtectedSymbol]] = {}  # filename -> protected symbols
+
+    def analyze_codebase(
+        self,
+        base_files: Dict[str, str],
+        directory_files: List[Dict[str, Any]]
+    ) -> None:
+        """
+        Analyze all generated files to build the dependency map.
+
+        Args:
+            base_files: Main files like locustfile.py, test_data.py, utils.py
+            directory_files: Workflow files in subdirectories
+        """
+        # Collect all files
+        self.files = base_files.copy()
+        for file_dict in directory_files:
+            self.files.update(file_dict)
+
+        # Analyze each file
+        for filename, content in self.files.items():
+            self._analyze_file(filename, content)
+
+        # Build protected symbols map
+        self._build_protected_map()
+
+    def _analyze_file(self, filename: str, content: str) -> None:
+        """Analyze a single file for exports and imports."""
+        if not content:
+            return
+
+        # Extract exports (classes, functions, constants defined in this file)
+        self.exports[filename] = self._extract_exports(content)
+
+        # Extract imports from other local files
+        self.imports[filename] = self._extract_local_imports(content)
+
+    def _extract_exports(self, content: str) -> Set[str]:
+        """Extract all symbols defined in this file."""
+        exports = set()
+
+        try:
+            tree = ast.parse(content)
+            for node in ast.iter_child_nodes(tree):
+                if isinstance(node, ast.ClassDef):
+                    exports.add(node.name)
+                    # Also add methods as ClassName.method_name
+                    for item in node.body:
+                        if isinstance(item, ast.FunctionDef) and not item.name.startswith('_'):
+                            exports.add(f"{node.name}.{item.name}")
+                elif isinstance(node, ast.FunctionDef):
+                    exports.add(node.name)
+                elif isinstance(node, ast.Assign):
+                    # Constants like SOME_VALUE = ...
+                    for target in node.targets:
+                        if isinstance(target, ast.Name) and target.id.isupper():
+                            exports.add(target.id)
+        except SyntaxError:
+            # Fallback to regex
+            exports.update(re.findall(r'^class\s+(\w+)', content, re.MULTILINE))
+            exports.update(re.findall(r'^def\s+(\w+)', content, re.MULTILINE))
+            exports.update(re.findall(r'^([A-Z_]+)\s*=', content, re.MULTILINE))
+
+        return exports
+
+    def _extract_local_imports(self, content: str) -> Dict[str, Set[str]]:
+        """Extract imports from other local files."""
+        imports: Dict[str, Set[str]] = {}
+
+        # Match patterns like:
+        # from test_data import TestDataGenerator
+        # from utils import ResponseValidator, RequestLogger
+        # from workflows.base_workflow import BaseWorkflow
+        patterns = [
+            r'from\s+(\w+)\s+import\s+([^#\n]+)',
+            r'from\s+workflows\.(\w+)\s+import\s+([^#\n]+)',
+        ]
+
+        for pattern in patterns:
+            for match in re.finditer(pattern, content):
+                source_file = match.group(1)
+                if not source_file.endswith('.py'):
+                    source_file += '.py'
+                imported_symbols = match.group(2)
+
+                # Parse the imported symbols
+                symbols = set()
+                for sym in imported_symbols.split(','):
+                    sym = sym.strip()
+                    # Handle 'as' aliases
+                    if ' as ' in sym:
+                        sym = sym.split(' as ')[0].strip()
+                    if sym and sym != '*':
+                        symbols.add(sym)
+
+                if source_file not in imports:
+                    imports[source_file] = set()
+                imports[source_file].update(symbols)
+
+        return imports
+
+    def _build_protected_map(self) -> None:
+        """Build the map of protected symbols for each file."""
+        for filename in self.files:
+            self.protected[filename] = []
+
+        # For each file, find which of its exports are used by other files
+        for filename, exports in self.exports.items():
+            for symbol in exports:
+                used_by = []
+
+                # Check which other files import this symbol
+                for other_file, other_imports in self.imports.items():
+                    if other_file == filename:
+                        continue
+
+                    # Check if this file imports from our file
+                    for source, symbols in other_imports.items():
+                        if source == filename or source.replace('.py', '') in filename:
+                            if symbol in symbols or symbol.split('.')[-1] in symbols:
+                                used_by.append(other_file)
+
+                if used_by:
+                    # Determine symbol type
+                    if '.' in symbol:
+                        symbol_type = 'method'
+                    elif symbol.isupper():
+                        symbol_type = 'constant'
+                    elif symbol[0].isupper():
+                        symbol_type = 'class'
+                    else:
+                        symbol_type = 'function'
+
+                    protected_symbol = ProtectedSymbol(
+                        name=symbol,
+                        symbol_type=symbol_type,
+                        defined_in=filename,
+                        used_by=used_by,
+                        reason=f"Imported by: {', '.join(used_by)}"
+                    )
+                    self.protected[filename].append(protected_symbol)
+
+    def get_constraints_for_file(self, filename: str) -> str:
+        """
+        Generate AI constraints for a specific file.
+
+        Returns a formatted string that tells the AI what it MUST preserve.
+        """
+        if filename not in self.protected:
+            return ""
+
+        protected_symbols = self.protected[filename]
+        if not protected_symbols:
+            return "No external dependencies. You can freely modify this file."
+
+        constraints = []
+        constraints.append("🔒 PROTECTED SYMBOLS (DO NOT REMOVE - used by other files):")
+        constraints.append("")
+
+        # Group by type
+        by_type: Dict[str, List[ProtectedSymbol]] = {}
+        for sym in protected_symbols:
+            if sym.symbol_type not in by_type:
+                by_type[sym.symbol_type] = []
+            by_type[sym.symbol_type].append(sym)
+
+        for sym_type, symbols in by_type.items():
+            constraints.append(f"  {sym_type.upper()}ES:")
+            for sym in symbols:
+                constraints.append(f"    - {sym.name}")
+                constraints.append(f"      Reason: {sym.reason}")
+            constraints.append("")
+
+        constraints.append("✅ You MAY:")
+        constraints.append("  - ADD new methods to existing classes")
+        constraints.append("  - ADD new helper functions")
+        constraints.append("  - MODIFY method implementations (keep signatures)")
+        constraints.append("  - ADD new classes")
+        constraints.append("")
+        constraints.append("❌ You MUST NOT:")
+        constraints.append("  - DELETE or RENAME any protected symbol above")
+        constraints.append("  - CHANGE the signature of protected methods")
+        constraints.append("  - REMOVE imports that other files depend on")
+
+        return "\n".join(constraints)
+
+    def get_full_context(self) -> str:
+        """Get a summary of the entire codebase structure for AI context."""
+        context = []
+        context.append("📁 CODEBASE STRUCTURE:")
+        context.append("")
+
+        for filename, exports in self.exports.items():
+            context.append(f"  {filename}:")
+            if exports:
+                context.append(f"    Exports: {', '.join(sorted(exports)[:10])}")
+                if len(exports) > 10:
+                    context.append(f"    ... and {len(exports) - 10} more")
+            context.append("")
+
+        return "\n".join(context)
+
+
+@dataclass
 class ErrorClassification:
     """Classification of an error for retry logic"""
 
@@ -295,9 +525,11 @@ class EnhancementProcessor:
         self,
         ai_config: Optional[AIEnhancementConfig],
         locust_generator: "HybridLocustGenerator",
+        awareness: Optional[CodebaseAwareness] = None,
     ) -> None:
         self.ai_config = ai_config
         self.locust_generator = locust_generator
+        self.awareness = awareness
 
     async def process_main_locust_enhancement(
         self,
@@ -468,6 +700,13 @@ class EnhancementProcessor:
         enhancements = []
         original_content = base_files.get(test_data_file_path, "")
 
+        # Get constraints from codebase awareness
+        constraints = ""
+        if self.awareness:
+            constraints = self.awareness.get_constraints_for_file(test_data_file_path)
+            if constraints:
+                logger.info(f"📋 Applying constraints to {test_data_file_path}")
+
         if self.ai_config and self.ai_config.enhance_test_data and original_content:
             enhanced_test_data = await self.locust_generator.enhance_test_data_file(
                 original_content,
@@ -476,6 +715,7 @@ class EnhancementProcessor:
                 base_files.get(data_provider_path, ""),
                 base_files.get("db_config.py", ""),
                 data_provider_path,
+                constraints=constraints,  # Pass constraints to AI
             )
             # Use safe enhancement with validation and fallback
             validated_content = self.locust_generator._safe_enhance_file(
@@ -498,9 +738,16 @@ class EnhancementProcessor:
         enhancements = []
         original_content = base_files.get("utils.py", "")
 
+        # Get constraints from codebase awareness
+        constraints = ""
+        if self.awareness:
+            constraints = self.awareness.get_constraints_for_file("utils.py")
+            if constraints:
+                logger.info(f"📋 Applying constraints to utils.py")
+
         if self.ai_config and self.ai_config.enhance_validation and original_content:
             enhanced_validation = await self.locust_generator._enhance_validation(
-                original_content, endpoints
+                original_content, endpoints, constraints=constraints
             )
             # Use safe enhancement with validation and fallback
             validated_content = self.locust_generator._safe_enhance_file(
@@ -794,7 +1041,17 @@ class HybridLocustGenerator:
         db_type: str = "",
     ) -> EnhancementResult:
         """Process all enhancements using the enhancement processor"""
-        processor = EnhancementProcessor(self.ai_config, self)
+        # Analyze codebase to understand dependencies
+        awareness = CodebaseAwareness()
+        awareness.analyze_codebase(base_files, directory_files)
+
+        # Log the protected symbols for debugging
+        logger.info("📊 Codebase analysis complete:")
+        for filename, protected in awareness.protected.items():
+            if protected:
+                logger.info(f"  {filename}: {len(protected)} protected symbols")
+
+        processor = EnhancementProcessor(self.ai_config, self, awareness)
 
         enhanced_files = base_files.copy()
         enhanced_directory_files = []
@@ -918,6 +1175,7 @@ class HybridLocustGenerator:
         data_provider: str = "",
         db_config: str = "",
         data_provider_path: str = "",
+        constraints: str = "",
     ) -> Optional[str]:
         """Enhance test data generation with domain knowledge"""
 
@@ -936,6 +1194,7 @@ class HybridLocustGenerator:
                 "data_provider_content": data_provider,
                 "db_config": db_config,
                 "data_provider_path": data_provider_path,
+                "constraints": constraints,  # Pass constraints to template
             }
 
             # Render enhanced content
@@ -949,7 +1208,7 @@ class HybridLocustGenerator:
         return ""
 
     async def _enhance_validation(
-        self, base_content: str, endpoints: List[Endpoint]
+        self, base_content: str, endpoints: List[Endpoint], constraints: str = ""
     ) -> Optional[str]:
         """Enhance response validation with endpoint-specific checks"""
 
@@ -959,7 +1218,9 @@ class HybridLocustGenerator:
 
             # Render enhanced content
             prompt = template.render(
-                base_content=base_content, validation_patterns=validation_patterns
+                base_content=base_content,
+                validation_patterns=validation_patterns,
+                constraints=constraints,  # Pass constraints to template
             )
             enhanced_content = await self._call_ai_service(prompt)
             if enhanced_content:

--- a/src/devdox_ai_locust/locust_generator.py
+++ b/src/devdox_ai_locust/locust_generator.py
@@ -18,6 +18,14 @@ from datetime import datetime
 
 
 from devdox_ai_locust.utils.open_ai_parser import Endpoint, Parameter
+from devdox_ai_locust.utils.naming import (
+    DefaultNamingStrategy,
+    to_workflow_module,
+    to_workflow_filename,
+    to_task_methods_class,
+    to_api_user_class,
+    to_param_var,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -219,10 +227,15 @@ class LocustTestGenerator:
                 indented_task_methods = self._indent_methods(
                     task_methods, indent_level=1
                 )
+                # Use centralized naming strategy for consistent naming
+                task_methods_class_name = to_task_methods_class(group)
+                api_user_class_name = to_api_user_class(group)
                 file_content = self._build_endpoint_template(
-                    api_info, indented_task_methods, group
+                    api_info, indented_task_methods, group,
+                    task_methods_class_name, api_user_class_name
                 )
-                file_name = f"{group}_workflow.py".replace("-", "_")
+                # Use centralized naming for filename
+                file_name = to_workflow_filename(group)
 
                 workflows.append({file_name: file_content})
 
@@ -238,11 +251,20 @@ class LocustTestGenerator:
             return []
 
     def _build_endpoint_template(
-        self, api_info: Dict[str, Any], task_methods_content: str, group: str
+        self,
+        api_info: Dict[str, Any],
+        task_methods_content: str,
+        group: str,
+        task_methods_class_name: str,
+        api_user_class_name: str,
     ) -> str:
         template = self.jinja_env.get_template("endpoint_template.py.j2")
         return template.render(
-            api_info=api_info, group=group, task_methods_content=task_methods_content
+            api_info=api_info,
+            group=group,
+            task_methods_content=task_methods_content,
+            task_methods_class_name=task_methods_class_name,
+            api_user_class_name=api_user_class_name,
         )
 
     def _generate_main_locustfile(
@@ -279,7 +301,7 @@ class LocustTestGenerator:
 
             # Properly indent task methods for class inclusion
             indented_task_methods = self._indent_methods(task_methods, indent_level=1)
-            indented_task_methods = ""
+
             # Generate the complete file content
             return self._build_locustfile_template(
                 api_info=api_info,
@@ -332,11 +354,12 @@ class LocustTestGenerator:
         import_group_tasks = ""
         tasks = []
         for group in groups:
-            file_name = group.lower().replace("-", "_")
-            class_name = group.capitalize().replace("-", "")
-            import_group_tasks += f"""from workflows.{file_name}_workflow import {class_name}TaskMethods\n"""
-            tasks.append(f"{class_name}TaskMethods")
-        tasks_str = "[" + ",".join(tasks) + "]"
+            # Use centralized naming for consistent imports
+            module_name = to_workflow_module(group)
+            class_name = to_task_methods_class(group)
+            import_group_tasks += f"""from workflows.{module_name}_workflow import {class_name}\n"""
+            tasks.append(class_name)
+        tasks_str = "[" + ", ".join(tasks) + "]"
         template = self.jinja_env.get_template("locust.py.j2")
 
         # Prepare template context
@@ -439,18 +462,20 @@ class LocustTestGenerator:
         return name if name else f"{endpoint.method.lower()}_endpoint"
 
     def _generate_path_with_params(self, endpoint: Endpoint) -> str:
-        """Generate path with parameter placeholders"""
+        """Generate path with sanitized parameter placeholders for valid Python f-strings"""
         path = endpoint.path
 
-        # Replace path parameters with f-string format
+        # Replace path parameters with sanitized f-string format
         for param in endpoint.parameters:
             if param.location.value == "path":
-                path = path.replace(f"{{{param.name}}}", f"{{{param.name}}}")
+                # Use sanitized variable name for valid Python identifier
+                safe_name = to_param_var(param.name)
+                path = path.replace(f"{{{param.name}}}", f"{{{safe_name}}}")
 
         return path
 
     def _generate_path_params_code(self, endpoint: Endpoint) -> str:
-        """Generate code for path parameters"""
+        """Generate code for path parameters with sanitized variable names"""
         path_params = [p for p in endpoint.parameters if p.location.value == "path"]
 
         if not path_params:
@@ -458,19 +483,20 @@ class LocustTestGenerator:
 
         code_lines = []
         for param in path_params:
+            # Use sanitized variable name for valid Python identifier
+            safe_name = to_param_var(param.name)
             if param.type.startswith("integer"):
-                code_lines.append(f"{param.name} = data_generator.generate_integer()")
+                code_lines.append(f"{safe_name} = data_generator.generate_integer()")
             elif param.type == "string":
                 if "id" in param.name.lower():
-                    code_lines.append(f"{param.name} = data_generator.generate_id()")
+                    code_lines.append(f"{safe_name} = data_generator.generate_id()")
                 else:
                     code_lines.append(
-                        f"{param.name} = data_generator.generate_string()"
+                        f"{safe_name} = data_generator.generate_string()"
                     )
-
             else:
                 code_lines.append(
-                    f'{param.name} = data_generator.generate_value("{param.type}")'
+                    f'{safe_name} = data_generator.generate_value("{param.type}")'
                 )
 
         return "\n".join(code_lines)
@@ -594,8 +620,16 @@ class LocustTestGenerator:
         endpoints: List[Endpoint],
         include_auth_endpoints: bool = True,
     ) -> Dict[str, List[Endpoint]]:
-        """Group endpoints by their tags"""
+        """
+        Group endpoints by their tags.
+
+        If include_auth_endpoints is True, endpoints matching auth keywords
+        are placed ONLY in the Authentication group (not duplicated to their tags).
+        """
         grouped: Dict[str, List[Endpoint]] = {}
+        # Track endpoints already assigned to auth to avoid duplication
+        auth_assigned: set = set()
+
         # Define authentication-related keywords to check for in paths
         auth_keywords = [
             "login",
@@ -629,18 +663,34 @@ class LocustTestGenerator:
             path_lower = endpoint_path.lower()
             return any(keyword in path_lower for keyword in auth_keywords)
 
+        def endpoint_key(ep: Endpoint) -> str:
+            """Create unique key for endpoint deduplication"""
+            return f"{ep.method}:{ep.path}"
+
         for endpoint in endpoints:
-            tags = endpoint.tags if endpoint.tags else ["default"]
+            ep_key = endpoint_key(endpoint)
+
+            # Check if this is an auth endpoint
             if is_auth_endpoint(endpoint.path) and include_auth_endpoints:
-                # Add to authentication group regardless of tags
+                # Add to authentication group ONLY (not to tag groups)
                 if "Authentication" not in grouped:
                     grouped["Authentication"] = []
-                grouped["Authentication"].append(endpoint)
 
+                # Deduplicate within the authentication group
+                if ep_key not in auth_assigned:
+                    grouped["Authentication"].append(endpoint)
+                    auth_assigned.add(ep_key)
+                continue  # Skip adding to tag groups
+
+            # For non-auth endpoints, add to tag groups
+            tags = endpoint.tags if endpoint.tags else ["default"]
             for tag in tags:
                 if tag not in grouped:
                     grouped[tag] = []
-                grouped[tag].append(endpoint)
+                # Deduplicate within each tag group
+                existing_keys = {endpoint_key(e) for e in grouped[tag]}
+                if ep_key not in existing_keys:
+                    grouped[tag].append(endpoint)
 
         return grouped
 

--- a/src/devdox_ai_locust/locust_generator.py
+++ b/src/devdox_ai_locust/locust_generator.py
@@ -346,8 +346,6 @@ class LocustTestGenerator:
         template = self.jinja_env.get_template("fallback_locust.py.j2")
         return template.render(api_info=api_info)
 
-    from typing import Dict, Any
-
     def _build_locustfile_template(
         self, api_info: Dict[str, Any], task_methods_content: str, groups: List[str]
     ) -> str:
@@ -368,7 +366,7 @@ class LocustTestGenerator:
             "task_methods_content": task_methods_content,
             "tasks_str": tasks_str,
             "api_info": api_info,
-            "generated_task_classes": self._generate_user_classes(),
+            "generated_task_classes": self._generate_user_classes(tasks),
             "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
 
@@ -703,13 +701,20 @@ class LocustTestGenerator:
 
         return "\n".join(methods)
 
-    def _generate_user_classes(self) -> str:
+    def _generate_user_classes(self, tasks: List[str]) -> str:
         """
-        **FIXED: Generate user classes with proper structure**
-        """
+        Generate user classes with proper structure.
 
+        Args:
+            tasks: List of TaskSet class names to assign to user classes
+
+        Returns:
+            Rendered user classes code string
+        """
+        # Format tasks list as Python list literal: [Class1, Class2, ...]
+        tasks_list = "[" + ", ".join(tasks) + "]"
         template = self.jinja_env.get_template("user_classes.py.j2")
-        return template.render()
+        return template.render(tasks_list=tasks_list)
 
     def _generate_test_data_file(self, db_type: str = "") -> str:
         """Generate test_data.py file content"""

--- a/src/devdox_ai_locust/prompt/base_workflow.j2
+++ b/src/devdox_ai_locust/prompt/base_workflow.j2
@@ -2,9 +2,10 @@ CRITICAL CONSTRAINTS: Only use endpoints that exist in the OpenAPI specification
 
 **CRITICAL: DO NOT INVENT AUTHENTICATION ENDPOINTS**
 - ONLY use authentication endpoints that are EXPLICITLY listed in the auth_endpoints variable below
-- If auth_endpoints is empty or contains no login/logout endpoints, DO NOT generate login_and_get_token() or logout_session() methods
-- NEVER invent endpoints like "/api/v1/login", "/login", "/auth/login", "/api/v1/logout" unless they appear in the OpenAPI spec
-- If no authentication endpoints exist, skip authentication entirely and use config.api_key for authorization
+- If auth_endpoints is empty, DO NOT generate login_and_get_token() or logout_session() methods
+- Authentication endpoints may have various names (e.g., /auth/token, /oauth/authorize, /session, /authenticate, etc.) - use whatever is in auth_endpoints
+- NEVER invent endpoint paths - use the EXACT paths from auth_endpoints
+- If no authentication endpoints exist, skip endpoint-based authentication and use config.api_key for authorization instead
 
 **CRITICAL: catch_response=True REQUIRES with-block**
 When using `catch_response=True`, you MUST use a `with` statement. The `response.success()` and `response.failure()` methods are ONLY valid inside the context manager.
@@ -46,18 +47,18 @@ STRICT REQUIREMENTS:
    Check Authentication Endpoints: {{ auth_endpoints }}
 
    **CRITICAL: DO NOT INVENT AUTHENTICATION ENDPOINTS!**
-   - ONLY implement login_and_get_token() if a login endpoint EXISTS in auth_endpoints above
-   - ONLY implement logout_session() if a logout endpoint EXISTS in auth_endpoints above
-   - If auth_endpoints is empty or has no login/logout endpoints, DO NOT create these methods
-   - Use the EXACT endpoint path from auth_endpoints, never invent paths like "/api/v1/login"
+   - ONLY implement authentication methods if auth_endpoints contains endpoints
+   - If auth_endpoints is empty, DO NOT create login_and_get_token() or logout_session() methods
+   - Use the EXACT endpoint paths from auth_endpoints (could be /auth/token, /oauth/authorize, /session, etc.)
+   - NEVER invent paths - use whatever authentication endpoints are provided in auth_endpoints
 
    **CRITICAL: `login_and_get_token` and `logout_session` are NOT defined in parent classes.**
    These methods must be defined in the workflow class itself and called via `self`, NOT `super()`.
 
    **Step 1: Check if workflow class needs authentication methods**
-   - FIRST: Check if auth_endpoints contains actual login/logout endpoints
-   - If NO login endpoint exists in auth_endpoints: DO NOT create login_and_get_token()
-   - If NO logout endpoint exists in auth_endpoints: DO NOT create logout_session()
+   - FIRST: Check if auth_endpoints contains any authentication endpoints
+   - If auth_endpoints is empty: DO NOT create login_and_get_token() or logout_session()
+   - If auth_endpoints has endpoints: Use them for authentication (regardless of their names)
    - If auth endpoints exist AND the workflow class doesn't have auth methods, ADD them
 
    **Step 2: Correct Implementation Pattern (ONLY if auth endpoints exist):**
@@ -80,18 +81,19 @@ STRICT REQUIREMENTS:
                self.logout_session()  # Call via self - defined in THIS class
            super().on_stop()
 
-       # ONLY define this method if a login endpoint EXISTS in auth_endpoints
+       # ONLY define this method if auth_endpoints contains authentication endpoints
        def login_and_get_token(self):
-           """Login and store JWT/Bearer token for API requests"""
+           """Authenticate and store token for API requests"""
            # Use the EXACT endpoint from auth_endpoints - DO NOT invent endpoints!
-           login_endpoint = "/actual/endpoint/from/auth_endpoints"  # Replace with real endpoint
+           # Could be /auth/token, /oauth/authorize, /session, /authenticate, etc.
+           auth_endpoint = "/actual/endpoint/from/auth_endpoints"  # Replace with real endpoint from auth_endpoints
            login_data = {
                "email": "test@example.com",
                "password": "test_password"
                # Use actual login schema from auth endpoints
            }
            # CRITICAL: Must use 'with' block when using catch_response=True
-           with self.client.post(login_endpoint, json=login_data, catch_response=True) as response:
+           with self.client.post(auth_endpoint, json=login_data, catch_response=True) as response:
                if response.status_code == 200:
                    response_data = response.json()
                    # Extract token from response (adapt to actual response structure)
@@ -112,14 +114,15 @@ STRICT REQUIREMENTS:
                else:
                    response.failure(f"Login failed: {response.status_code}")
 
-       # ONLY define this method if a logout endpoint EXISTS in auth_endpoints
+       # ONLY define this method if auth_endpoints contains a session termination endpoint
        def logout_session(self):
-           """Logout and clear authentication token"""
+           """End session and clear authentication token"""
            # Use the EXACT endpoint from auth_endpoints - DO NOT invent endpoints!
-           logout_endpoint = "/actual/endpoint/from/auth_endpoints"  # Replace with real endpoint
+           # Could be /auth/revoke, /session, /logout, /oauth/revoke, etc.
+           session_end_endpoint = "/actual/endpoint/from/auth_endpoints"  # Replace with real endpoint from auth_endpoints
            if hasattr(self, 'auth_token') and self.auth_token:
                # CRITICAL: Must use 'with' block when using catch_response=True
-               with self.client.post(logout_endpoint, catch_response=True) as response:
+               with self.client.post(session_end_endpoint, catch_response=True) as response:
                    if response.status_code in [200, 204]:
                        self.auth_token = None
                        # Remove auth header
@@ -148,8 +151,9 @@ STRICT REQUIREMENTS:
 
    # WRONG #3 - inventing endpoints that don't exist in OpenAPI spec!
    def login_and_get_token(self):
-       # DO NOT use endpoints unless they exist in auth_endpoints!
-       with self.client.post("/api/v1/login", ...)  # WRONG if not in spec!
+       # DO NOT invent endpoints - use ONLY what's in auth_endpoints!
+       # If auth_endpoints has "/auth/token", use that exact path
+       with self.client.post("/api/v1/login", ...)  # WRONG if this path isn't in auth_endpoints!
 ```
 
 4. TASK METHOD ENHANCEMENT PATTERN:

--- a/src/devdox_ai_locust/prompt/base_workflow.j2
+++ b/src/devdox_ai_locust/prompt/base_workflow.j2
@@ -17,32 +17,29 @@ STRICT REQUIREMENTS:
 3. AUTHENTICATION INTEGRATION STRATEGY:
    Check Authentication Endpoints: {{ auth_endpoints }}
 
-   **Step 1: Analyze base_workflow.py for existing authentication:**
-   - Parse base_workflow content for existing login/logout/auth methods
-   - Check if BaseTaskMethods or BaseAPIUser already handle authentication
-   - Identify existing token management patterns
+   **CRITICAL: `login_and_get_token` and `logout_session` are NOT defined in parent classes.**
+   These methods must be defined in the workflow class itself and called via `self`, NOT `super()`.
 
-   **Step 2: Authentication Decision Logic:**
+   **Step 1: Check if workflow class needs authentication methods**
+   - If auth endpoints exist and the workflow class doesn't have auth methods, ADD them
+   - Define login_and_get_token() and logout_session() in the workflow class
+   - Call them via `self` in on_start/on_stop
 
-   **IF base_workflow.py contains authentication methods:**
+   **Step 2: Correct Implementation Pattern:**
+
 ```python
-   # INHERIT authentication from base classes
-   class YourWorkflowTaskMethods(BaseTaskMethods, SequentialTaskSet):
+   class YourWorkflowTaskMethods(SequentialTaskSet, BaseTaskMethods):
+       """Task methods with authentication support"""
+
        def on_start(self):
-           super().on_start()  # Uses base auth
-           logger.info("Using inherited authentication from base workflow")
+           """Initialize session and authenticate"""
+           super().on_start()  # Calls BaseTaskMethods.on_start() for setup
+           self.login_and_get_token()  # Call via self - defined in THIS class
 
        def on_stop(self):
-           super().on_stop()  # Uses base cleanup
-```
-
-   **IF base_workflow.py lacks authentication AND auth endpoints exist:**
-```python
-   # ADD authentication to workflow-specific class (NOT BaseTaskMethods)
-   class YourWorkflowTaskMethods(BaseTaskMethods, SequentialTaskSet):
-       def on_start(self):
-           super().on_start()  # Keep base functionality
-           self.login_and_get_token()  # Add auth for this workflow
+           """Cleanup session"""
+           self.logout_session()  # Call via self - defined in THIS class
+           super().on_stop()
 
        def login_and_get_token(self):
            """Login and store JWT/Bearer token for API requests"""
@@ -52,7 +49,7 @@ STRICT REQUIREMENTS:
                # Use actual login schema from auth endpoints
            }
            with self.client.post("/login", json=login_data, catch_response=True) as response:
-               #use actual endpoint from login endpoint
+               # Use actual endpoint from login endpoint
                if response.status_code == 200:
                    response_data = response.json()
                    # Extract token from response (adapt to actual response structure)
@@ -77,7 +74,7 @@ STRICT REQUIREMENTS:
            """Logout and clear authentication token"""
            if hasattr(self, 'auth_token') and self.auth_token:
                with self.client.post("/logout", catch_response=True) as response:
-                   #use actual endpoint from logout endpoint
+                   # Use actual endpoint from logout endpoint
                    if response.status_code in [200, 204]:
                        self.auth_token = None
                        # Remove auth header
@@ -86,21 +83,15 @@ STRICT REQUIREMENTS:
                        response.success()
                    else:
                        response.failure(f"Logout failed: {response.status_code}")
+```
 
-       def handle_401_retry(self, method, path, **kwargs):
-           """Handle 401 responses with automatic re-authentication"""
-           response = self.make_request(method, path, **kwargs)
-
-           # Check if response indicates auth failure
-           if (hasattr(response, 'status_code') and response.status_code == 401) or \
-              (isinstance(response, dict) and response.get('status_code') == 401):
-               logger.warning(f"401 Unauthorized - re-authenticating and retrying {method} {path}")
-               # Re-authenticate
-               self.login_and_get_token()
-               # Retry original request
-               response = self.make_request(method, path, **kwargs)
-
-           return response
+   **WRONG PATTERN - DO NOT USE:**
+```python
+   # WRONG - these methods don't exist in parent classes!
+   def on_start(self):
+       super().on_start()
+       if hasattr(super(), 'login_and_get_token'):  # WRONG
+           super().login_and_get_token()  # WRONG - will cause IDE error
 ```
 
 4. TASK METHOD ENHANCEMENT PATTERN:

--- a/src/devdox_ai_locust/prompt/base_workflow.j2
+++ b/src/devdox_ai_locust/prompt/base_workflow.j2
@@ -1,5 +1,33 @@
 CRITICAL CONSTRAINTS: Only use endpoints that exist in the OpenAPI specification. DO NOT create, modify, or reference any endpoints not listed below.
 
+**CRITICAL: DO NOT INVENT AUTHENTICATION ENDPOINTS**
+- ONLY use authentication endpoints that are EXPLICITLY listed in the auth_endpoints variable below
+- If auth_endpoints is empty or contains no login/logout endpoints, DO NOT generate login_and_get_token() or logout_session() methods
+- NEVER invent endpoints like "/api/v1/login", "/login", "/auth/login", "/api/v1/logout" unless they appear in the OpenAPI spec
+- If no authentication endpoints exist, skip authentication entirely and use config.api_key for authorization
+
+**CRITICAL: catch_response=True REQUIRES with-block**
+When using `catch_response=True`, you MUST use a `with` statement. The `response.success()` and `response.failure()` methods are ONLY valid inside the context manager.
+
+CORRECT PATTERN:
+```python
+with self.client.post("/endpoint", json=data, catch_response=True) as response:
+    if response.status_code == 200:
+        response.success()  # Valid - inside with-block
+    else:
+        response.failure("Error message")  # Valid - inside with-block
+```
+
+WRONG PATTERN (CAUSES RUNTIME ERROR):
+```python
+# WRONG - will cause LocustError: "Tried to set status on a request that has not yet been made"
+response = self.client.post("/endpoint", json=data, catch_response=True)
+if response.status_code == 200:
+    response.success()  # RUNTIME ERROR - outside with-block!
+else:
+    response.failure("Error message")  # RUNTIME ERROR - outside with-block!
+```
+
 TASK: Enhance this Locust workflow file with realistic load testing patterns and LOGICAL TASK ORDERING while PRESERVING ALL EXISTING FUNCTIONALITY AND CLASSES.
 
 STRICT REQUIREMENTS:
@@ -17,15 +45,22 @@ STRICT REQUIREMENTS:
 3. AUTHENTICATION INTEGRATION STRATEGY:
    Check Authentication Endpoints: {{ auth_endpoints }}
 
+   **CRITICAL: DO NOT INVENT AUTHENTICATION ENDPOINTS!**
+   - ONLY implement login_and_get_token() if a login endpoint EXISTS in auth_endpoints above
+   - ONLY implement logout_session() if a logout endpoint EXISTS in auth_endpoints above
+   - If auth_endpoints is empty or has no login/logout endpoints, DO NOT create these methods
+   - Use the EXACT endpoint path from auth_endpoints, never invent paths like "/api/v1/login"
+
    **CRITICAL: `login_and_get_token` and `logout_session` are NOT defined in parent classes.**
    These methods must be defined in the workflow class itself and called via `self`, NOT `super()`.
 
    **Step 1: Check if workflow class needs authentication methods**
-   - If auth endpoints exist and the workflow class doesn't have auth methods, ADD them
-   - Define login_and_get_token() and logout_session() in the workflow class
-   - Call them via `self` in on_start/on_stop
+   - FIRST: Check if auth_endpoints contains actual login/logout endpoints
+   - If NO login endpoint exists in auth_endpoints: DO NOT create login_and_get_token()
+   - If NO logout endpoint exists in auth_endpoints: DO NOT create logout_session()
+   - If auth endpoints exist AND the workflow class doesn't have auth methods, ADD them
 
-   **Step 2: Correct Implementation Pattern:**
+   **Step 2: Correct Implementation Pattern (ONLY if auth endpoints exist):**
 
 ```python
    class YourWorkflowTaskMethods(SequentialTaskSet, BaseTaskMethods):
@@ -34,22 +69,29 @@ STRICT REQUIREMENTS:
        def on_start(self):
            """Initialize session and authenticate"""
            super().on_start()  # Calls BaseTaskMethods.on_start() for setup
-           self.login_and_get_token()  # Call via self - defined in THIS class
+           # ONLY call if login endpoint exists in auth_endpoints
+           if hasattr(self, 'login_and_get_token'):
+               self.login_and_get_token()  # Call via self - defined in THIS class
 
        def on_stop(self):
            """Cleanup session"""
-           self.logout_session()  # Call via self - defined in THIS class
+           # ONLY call if logout endpoint exists in auth_endpoints
+           if hasattr(self, 'logout_session'):
+               self.logout_session()  # Call via self - defined in THIS class
            super().on_stop()
 
+       # ONLY define this method if a login endpoint EXISTS in auth_endpoints
        def login_and_get_token(self):
            """Login and store JWT/Bearer token for API requests"""
+           # Use the EXACT endpoint from auth_endpoints - DO NOT invent endpoints!
+           login_endpoint = "/actual/endpoint/from/auth_endpoints"  # Replace with real endpoint
            login_data = {
                "email": "test@example.com",
                "password": "test_password"
                # Use actual login schema from auth endpoints
            }
-           with self.client.post("/login", json=login_data, catch_response=True) as response:
-               # Use actual endpoint from login endpoint
+           # CRITICAL: Must use 'with' block when using catch_response=True
+           with self.client.post(login_endpoint, json=login_data, catch_response=True) as response:
                if response.status_code == 200:
                    response_data = response.json()
                    # Extract token from response (adapt to actual response structure)
@@ -70,11 +112,14 @@ STRICT REQUIREMENTS:
                else:
                    response.failure(f"Login failed: {response.status_code}")
 
+       # ONLY define this method if a logout endpoint EXISTS in auth_endpoints
        def logout_session(self):
            """Logout and clear authentication token"""
+           # Use the EXACT endpoint from auth_endpoints - DO NOT invent endpoints!
+           logout_endpoint = "/actual/endpoint/from/auth_endpoints"  # Replace with real endpoint
            if hasattr(self, 'auth_token') and self.auth_token:
-               with self.client.post("/logout", catch_response=True) as response:
-                   # Use actual endpoint from logout endpoint
+               # CRITICAL: Must use 'with' block when using catch_response=True
+               with self.client.post(logout_endpoint, catch_response=True) as response:
                    if response.status_code in [200, 204]:
                        self.auth_token = None
                        # Remove auth header
@@ -85,13 +130,26 @@ STRICT REQUIREMENTS:
                        response.failure(f"Logout failed: {response.status_code}")
 ```
 
-   **WRONG PATTERN - DO NOT USE:**
+   **WRONG PATTERNS - DO NOT USE:**
 ```python
-   # WRONG - these methods don't exist in parent classes!
+   # WRONG #1 - these methods don't exist in parent classes!
    def on_start(self):
        super().on_start()
        if hasattr(super(), 'login_and_get_token'):  # WRONG
            super().login_and_get_token()  # WRONG - will cause IDE error
+
+   # WRONG #2 - catch_response without with-block causes runtime error!
+   def login_and_get_token(self):
+       response = self.client.post("/login", json=data, catch_response=True)
+       if response.status_code == 200:
+           response.success()  # RUNTIME ERROR - must be inside 'with' block!
+       else:
+           response.failure("Failed")  # RUNTIME ERROR - must be inside 'with' block!
+
+   # WRONG #3 - inventing endpoints that don't exist in OpenAPI spec!
+   def login_and_get_token(self):
+       # DO NOT use endpoints unless they exist in auth_endpoints!
+       with self.client.post("/api/v1/login", ...)  # WRONG if not in spec!
 ```
 
 4. TASK METHOD ENHANCEMENT PATTERN:

--- a/src/devdox_ai_locust/prompt/test_data.j2
+++ b/src/devdox_ai_locust/prompt/test_data.j2
@@ -1,17 +1,13 @@
-Generate ONLY NEW METHODS to add to an existing TestDataGenerator class.
+You are enhancing a TestDataGenerator class for Locust load testing.
 
-DO NOT rewrite the existing class. DO NOT include the class definition.
-ONLY output new method definitions that can be added to the class.
+{% if constraints %}
+{{ constraints }}
+{% endif %}
 
-The existing TestDataGenerator class already has these methods (DO NOT recreate them):
-- generate_json_data()
-- generate_string()
-- generate_id()
-- generate_email()
-- generate_phone()
-- generate_date()
-- generate_url()
-- And many more...
+**EXISTING CODE**:
+```python
+{{base_content}}
+```
 
 API Context:
 - Endpoints: [{% for ep in endpoints -%}
@@ -19,31 +15,16 @@ API Context:
 - Schemas: {{ schemas_info }}
 
 {% if data_provider_content %}
-MongoDB is available via: mongo_data_provider.get_document(collection, query)
+**MongoDB Available** via:
+- mongo_data_provider.get_document(collection, query)
+- mongo_data_provider.get_multiple_documents(collection, count, query)
 {% endif %}
 
-Generate 3-5 NEW utility methods that would be useful for testing these specific endpoints.
-Focus on domain-specific data generation based on the API patterns.
+**YOUR TASK**:
+Enhance this file by ADDING new domain-specific methods. You may:
+- ADD new methods for generating test data specific to these endpoints
+- ADD MongoDB integration methods if MongoDB is available
+- IMPROVE existing method implementations (keep their signatures!)
 
-Example output format:
-<code>
-def generate_affiliate_data(self) -> Dict[str, Any]:
-    """Generate realistic affiliate data for testing."""
-    return {
-        "affiliate_id": self.generate_id("affiliate"),
-        "name": self.generate_string(prefix="Affiliate"),
-        "email": self.generate_email(),
-        "status": random.choice(["active", "pending", "inactive"])
-    }
-
-def generate_product_payload(self) -> Dict[str, Any]:
-    """Generate a product creation payload."""
-    return {
-        "name": self.generate_string(prefix="Product"),
-        "price": round(random.uniform(10.0, 1000.0), 2),
-        "category": random.choice(["electronics", "clothing", "food"])
-    }
-</code>
-
-Output ONLY new method definitions wrapped in <code></code> tags.
-Do NOT include imports, class definitions, or existing methods.
+Output the COMPLETE enhanced Python file wrapped in <code></code> tags.
+Remember: Protected symbols MUST remain in the output with unchanged signatures.

--- a/src/devdox_ai_locust/prompt/test_data.j2
+++ b/src/devdox_ai_locust/prompt/test_data.j2
@@ -1,202 +1,49 @@
-🚨 **CRITICAL PRESERVATION REQUIREMENT** 🚨
-You MUST preserve ALL existing classes, methods, and functionality from the current file.
-DO NOT delete, remove, or replace any existing code. Only ADD new functionality.
-The TestDataGenerator class and ALL its methods MUST remain intact.
+Generate ONLY NEW METHODS to add to an existing TestDataGenerator class.
 
-Enhance this Test Data Generator by ADDING new capabilities while PRESERVING everything that exists.
-{% if data_provider_content %}Add MongoDB integration for live data enrichment.{% endif %}
+DO NOT rewrite the existing class. DO NOT include the class definition.
+ONLY output new method definitions that can be added to the class.
 
-**EXISTING CODE TO PRESERVE (DO NOT DELETE ANY OF THIS)**:
-```python
-{{base_content}}
-```
+The existing TestDataGenerator class already has these methods (DO NOT recreate them):
+- generate_json_data()
+- generate_string()
+- generate_id()
+- generate_email()
+- generate_phone()
+- generate_date()
+- generate_url()
+- And many more...
 
-⚠️ WARNING: If you delete the TestDataGenerator class or any of its methods, your output will be rejected.
-
-
-{% if data_provider_content %}
-    Database config file content with path to DB{{ data_provider_path }}:
-    {{ db_config }}
-
-
-    **MONGODB DATA PROVIDER** (Available for Integration):
-    ```python
-    {{data_provider_content}}
-    ```
-{% endif %}
-
-
-API Endpoints Context:
-    - **Schemas**: {schemas_info}
-    - **Endpoints**: [{% for ep in endpoints -%}
-    "Path: {{ ep.path }}, Method: {{ ep.method }}, Tags: {{ ep.tags }}"{% if not loop.last %},{% endif %}{% endfor -%}]
-
-
-
-**CRITICAL REQUIREMENT**: Every method must have COMPLETE, FUNCTIONAL implementation. NO stubs, NO pass statements, NO placeholder comments.
-
-**IMPLEMENTATION SPECIFICATIONS**:
-{% set counter = namespace(value=1) %}
+API Context:
+- Endpoints: [{% for ep in endpoints -%}
+"{{ ep.method }} {{ ep.path }}"{% if not loop.last %}, {% endif %}{% endfor -%}]
+- Schemas: {{ schemas_info }}
 
 {% if data_provider_content %}
-    {{ counter.value }}.  **MongoDB Integration** (COMPLETE Implementation Required)
-```python
-def get_from_mongodb_or_generate(self, collection_name: str, entity_type: str, fallback_generator: callable = None, **kwargs) -> Dict[str, Any]:
-    \"\"\"COMPLETE implementation with full error handling, logging, and statistics\"\"\"
-    # IMPLEMENT: Full MongoDB integration with:
-    # - Statistics tracking (mongo_queries, cache_hits, fallback_generations)
-    # - Comprehensive error handling with specific exception types
-    # - Logging with appropriate levels (DEBUG, WARNING, ERROR)
-    # - Performance metrics collection
-    # - Graceful degradation when MongoDB unavailable
-    # - Return type validation and data sanitization
-```
-
-    {% set counter.value = counter.value + 1 %}
+MongoDB is available via: mongo_data_provider.get_document(collection, query)
 {% endif %}
 
-{{ counter.value }}. **Domain-Specific Data Generators**(COMPLETE Implementation Required)
-   - Add methods like `generate_affiliate_data()`, `generate_user_credentials()`, `generate_product_data()`
-   - Create realistic data based on API endpoint patterns (affiliate, user, product, etc.)
-   - Add specific payload generators for common API patterns
-    {% if data_provider_content %}- Use MongoDB data as templates when available{% endif %}
-   - Add `generate_realistic_data(entity_type: str)` for entity-specific data
-{% set counter.value = counter.value + 1 %}
+Generate 3-5 NEW utility methods that would be useful for testing these specific endpoints.
+Focus on domain-specific data generation based on the API patterns.
 
+Example output format:
+<code>
+def generate_affiliate_data(self) -> Dict[str, Any]:
+    """Generate realistic affiliate data for testing."""
+    return {
+        "affiliate_id": self.generate_id("affiliate"),
+        "name": self.generate_string(prefix="Affiliate"),
+        "email": self.generate_email(),
+        "status": random.choice(["active", "pending", "inactive"])
+    }
 
+def generate_product_payload(self) -> Dict[str, Any]:
+    """Generate a product creation payload."""
+    return {
+        "name": self.generate_string(prefix="Product"),
+        "price": round(random.uniform(10.0, 1000.0), 2),
+        "category": random.choice(["electronics", "clothing", "food"])
+    }
+</code>
 
-{{ counter.value }} **Realistic Data Generation**:
-   - Add `generate_realistic_data(entity_type: str, **kwargs)` for entity-specific data
-   - Create realistic data based on API endpoint patterns (user, product, order, etc.)
-   {% if data_provider_content %}- Integrate MongoDB data patterns into generated data {% endif %}
-   - Add business logic validation for generated data
-{% set counter.value = counter.value + 1 %}
-
-
-{{ counter.value }}. **Realistic ID Generation**:
-   - Add `generate_realistic_id(entity_type: str)` for entity-specific IDs
-   - Create correlated IDs (user_id -> session_id -> transaction_id)
-   - Add methods like `generate_affiliate_id()`, `generate_partner_id()`, etc.
-{% set counter.value = counter.value + 1 %}
-
-{{ counter.value }}. **Payload Templates**:
-   - Add `get_payload_template(endpoint_path: str, method: str)`
-   - Create endpoint-specific payload generators
-   - Add `generate_login_payload()`, `generate_registration_payload()`, etc.
-{% set counter.value = counter.value + 1 %}
-
-{{ counter.value }}. **Data Relationships & Correlation**:
-   - Add session management: `create_user_session()`, `get_session_data()`
-   - Create data dependency chains (parent-child relationships)
-   - Add `link_related_entities(parent_id, child_type)` for realistic relationships
-{% set counter.value = counter.value + 1 %}
-
-
-{{ counter.value }}. COMPLETE Implementation Required)
-    ```python
-    def cache_generated_data(self, key: str, data: Any, ttl_seconds: int = 300) -> None:
-    \"\"\"COMPLETE thread-safe caching implementation\"\"\"
-    # IMPLEMENT: Full caching system with:
-    # - Thread-safe operations using threading.Lock()
-    # - TTL (time-to-live) management with automatic expiration
-    # - Cache size limits with LRU eviction
-    # - Memory usage tracking and optimization
-    # - Cache hit/miss statistics
-    # - Data serialization/deserialization if needed
-
-    def get_cached_data(self, key: str) -> Optional[Any]:
-        \"\"\"COMPLETE cache retrieval with validation\"\"\"
-        # IMPLEMENT: Full cache retrieval with:
-        # - TTL validation and automatic cleanup
-        # - Thread-safe access
-        # - Statistics updating (cache_hits counter)
-        # - Data integrity validation
-        # - Proper None handling for cache misses
-
-    def get_or_create_entity(self, entity_type: str, **kwargs) -> Dict[str, Any]:
-        \"\"\"COMPLETE entity management with intelligent caching\"\"\"
-        # IMPLEMENT: Full entity lifecycle management:
-        # - Cache key generation from entity_type and kwargs
-        # - Cache lookup with TTL validation
-        # - MongoDB integration for real data
-        # - Fallback to realistic generation
-        # - Automatic caching of generated/retrieved data
-        # - Relationship tracking and linking
-    ```
-{% set counter.value = counter.value + 1 %}
-
-{{ counter.value }}. **Specialized Pattern Generators**:
-   - Add `generate_api_key_data()`, `generate_webhook_payload()`
-   - Create `generate_pagination_data()`, `generate_filter_data()`
-   - Add `generate_error_scenarios()` for negative testing
-{% set counter.value = counter.value + 1 %}
-
-{{ counter.value }}. **Validation & Constraints**:
-   - Add `validate_generated_data(data, schema)`
-   - Create constraint-aware generation
-   - Add business rule validation
-{% set counter.value = counter.value + 1 %}
-
-{% if data_provider_content %}
-    {{ counter.value }}. **MongoDB Integration Specifics**:
-    - **MANDATORY**: `mongo_data_provider.get_multiple_documents(collection_name, count, query)` when retrieving multiple realistic  to return list records from MongoDB.
-    - Use `mongo_data_provider.get_document(collection_name,query,projection)` when retrieving a single realistic record from MongoDB or fallback generation.
-    - Add `mongo_data_provider.preload_cache()` integration
-    - Use `mongo_config.enable_mongodb` for availability checking
-    - Implement proper connection error handling
-    - Add MongoDB query optimization
-    - Include data freshness validation
-    {% set counter.value = counter.value + 1 %}
-{% endif %}
-
-{% if data_provider_content %}
-
-**🚨 FINAL VALIDATION REQUIREMENTS**:
-
-The generated code MUST contain these exact function calls:
-1. `mongo_data_provider.get_multiple_documents()` - Used at least 5 times
-2. `mongo_data_provider.get_random_document()` - Used for single items only
-3. Both methods must have proper error handling and fallback generation
-
-
-**VERIFICATION CHECKLIST**:
-- [ ] `get_multiple_documents()` appears in at least 5 different methods
-- [ ] `get_document()` is used for single entity retrieval
-- [ ] No method uses only `get_document()` when batch data is needed
-- [ ] All MongoDB calls have try/catch error handling
-- [ ] All MongoDB calls have fallback generation
-**FAILURE CRITERIA**: If `get_multiple_documents()` appears less than 5 times in the generated code, the implementation is incomplete and must be regenerated.
-{% endif %}
-
-**OUTPUT REQUIREMENTS**:
-
-1. **ZERO Placeholder Methods**: Every method must be FULLY implemented
-2. **Production Quality**: Include proper error handling, logging, and documentation
-3. **Thread Safety**: All caching and state management must be thread-safe
-4. **Performance Optimized**: Efficient algorithms and memory usage
-5. **Comprehensive Testing**: Generate data that covers edge cases and business scenarios
-6. **Backward Compatibility**: All existing functionality must continue working
-7. **Rich Data**: Generate realistic, coherent data with proper relationships
-8. **Extensive Logging**: Use logging module with appropriate levels
-9. **Statistics Tracking**: Detailed metrics for monitoring and optimization
-10. **MongoDB Integration**: Seamless integration with provided data provider
-
-🚨 **CRITICAL SUCCESS CRITERIA**:
-- **PRESERVATION**: The TestDataGenerator class MUST be present with ALL original methods
-- **PRESERVATION**: ALL existing methods (generate_json_data, generate_string, generate_id, etc.) MUST remain
-- NO methods should contain `pass` or placeholder comments
-- ALL caching methods must be fully functional
-- ALL data generation must produce realistic, coherent data
-- ALL MongoDB integration must handle errors gracefully
-- ALL relationships must be properly tracked and maintained
-
-⚠️ **VALIDATION CHECK**: Your output MUST contain:
-1. `class TestDataGenerator` - The main class definition
-2. `def generate_json_data` - The JSON data generation method
-3. `def generate_string` - The string generation method
-4. `def generate_id` - The ID generation method
-5. ALL other methods from the original file
-
-Return the COMPLETE, PRODUCTION-READY Python file with the existing TestDataGenerator class fully preserved and enhanced.
-
-**Format**: Return ONLY the complete Python code wrapped in <code></code> tags with NO explanations outside the tags.
+Output ONLY new method definitions wrapped in <code></code> tags.
+Do NOT include imports, class definitions, or existing methods.

--- a/src/devdox_ai_locust/prompt/test_data.j2
+++ b/src/devdox_ai_locust/prompt/test_data.j2
@@ -1,10 +1,17 @@
-Evolve this Test Data Generator into a fully production-ready, intelligent data generation framework.
-{% if data_provider_content %}Incorporate MongoDB integration for live data enrichment, delivering a complete, robust, and realistic test data engine with domain awareness, caching, and smart relationships.{% endif %}
+🚨 **CRITICAL PRESERVATION REQUIREMENT** 🚨
+You MUST preserve ALL existing classes, methods, and functionality from the current file.
+DO NOT delete, remove, or replace any existing code. Only ADD new functionality.
+The TestDataGenerator class and ALL its methods MUST remain intact.
 
-**CURRENT STATE ANALYSIS**:
+Enhance this Test Data Generator by ADDING new capabilities while PRESERVING everything that exists.
+{% if data_provider_content %}Add MongoDB integration for live data enrichment.{% endif %}
+
+**EXISTING CODE TO PRESERVE (DO NOT DELETE ANY OF THIS)**:
 ```python
 {{base_content}}
 ```
+
+⚠️ WARNING: If you delete the TestDataGenerator class or any of its methods, your output will be rejected.
 
 
 {% if data_provider_content %}
@@ -175,12 +182,21 @@ The generated code MUST contain these exact function calls:
 10. **MongoDB Integration**: Seamless integration with provided data provider
 
 🚨 **CRITICAL SUCCESS CRITERIA**:
+- **PRESERVATION**: The TestDataGenerator class MUST be present with ALL original methods
+- **PRESERVATION**: ALL existing methods (generate_json_data, generate_string, generate_id, etc.) MUST remain
 - NO methods should contain `pass` or placeholder comments
 - ALL caching methods must be fully functional
 - ALL data generation must produce realistic, coherent data
 - ALL MongoDB integration must handle errors gracefully
 - ALL relationships must be properly tracked and maintained
 
-Return the COMPLETE, PRODUCTION-READY Python file with every method fully implemented and tested-quality code.
+⚠️ **VALIDATION CHECK**: Your output MUST contain:
+1. `class TestDataGenerator` - The main class definition
+2. `def generate_json_data` - The JSON data generation method
+3. `def generate_string` - The string generation method
+4. `def generate_id` - The ID generation method
+5. ALL other methods from the original file
 
-**Format**: Return ONLY the complete Python code wrapped in ```python``` tags with NO explanations outside the code block.
+Return the COMPLETE, PRODUCTION-READY Python file with the existing TestDataGenerator class fully preserved and enhanced.
+
+**Format**: Return ONLY the complete Python code wrapped in <code></code> tags with NO explanations outside the tags.

--- a/src/devdox_ai_locust/prompt/validation.j2
+++ b/src/devdox_ai_locust/prompt/validation.j2
@@ -1,17 +1,36 @@
-Enhance this utils file with smarter response validation:
+🚨 **CRITICAL PRESERVATION REQUIREMENT** 🚨
+You MUST preserve ALL existing classes, methods, and functionality from the current file.
+DO NOT delete, remove, or replace any existing code. Only ADD new functionality.
+The following classes MUST remain intact:
+- ResponseValidator
+- RequestLogger
+- PerformanceMonitor
+- DataManager
 
-Current File:
+**EXISTING CODE TO PRESERVE (DO NOT DELETE ANY OF THIS)**:
+```python
 {{base_content}}
+```
+
+⚠️ WARNING: If you delete any of the classes listed above, your output will be rejected.
 
 Validation Patterns Needed:
 {{ validation_patterns }}
 
-Enhance by:
-1. Adding endpoint-specific validation rules
-2. Creating schema-based response validation
-3. Adding business logic validation
-4. Implementing response data integrity checks
-5. Adding performance threshold validation
+**ENHANCEMENT INSTRUCTIONS** (ADD to existing code, do NOT replace):
+1. ADD endpoint-specific validation rules to ResponseValidator
+2. ADD schema-based response validation methods
+3. ADD business logic validation helpers
+4. ADD response data integrity checks
+5. ADD performance threshold validation to PerformanceMonitor
 
-Keep existing utility functions but add smarter validation logic.
-Output: Complete enhanced Python file content.
+⚠️ **VALIDATION CHECK**: Your output MUST contain:
+1. `class ResponseValidator` - The response validation class
+2. `class RequestLogger` - The request logging class
+3. `class PerformanceMonitor` - The performance monitoring class
+4. `class DataManager` - The data management class
+5. ALL existing methods from each class
+
+Return the COMPLETE enhanced Python file with ALL existing classes preserved and enhanced.
+
+**Format**: Return ONLY the complete Python code wrapped in <code></code> tags with NO explanations outside the tags.

--- a/src/devdox_ai_locust/prompt/validation.j2
+++ b/src/devdox_ai_locust/prompt/validation.j2
@@ -1,36 +1,31 @@
-🚨 **CRITICAL PRESERVATION REQUIREMENT** 🚨
-You MUST preserve ALL existing classes, methods, and functionality from the current file.
-DO NOT delete, remove, or replace any existing code. Only ADD new functionality.
-The following classes MUST remain intact:
-- ResponseValidator
-- RequestLogger
-- PerformanceMonitor
-- DataManager
+Generate ONLY NEW METHODS to add to the existing ResponseValidator class.
 
-**EXISTING CODE TO PRESERVE (DO NOT DELETE ANY OF THIS)**:
-```python
-{{base_content}}
-```
+DO NOT rewrite existing classes. DO NOT include class definitions.
+ONLY output new method definitions that can be added.
 
-⚠️ WARNING: If you delete any of the classes listed above, your output will be rejected.
+The existing classes already have these methods (DO NOT recreate them):
+- ResponseValidator: validate_response(), validate_status_code(), validate_json_structure()
+- RequestLogger: log_request(), log_response()
+- PerformanceMonitor: record_metric(), get_statistics()
+- DataManager: store_data(), get_data()
 
 Validation Patterns Needed:
 {{ validation_patterns }}
 
-**ENHANCEMENT INSTRUCTIONS** (ADD to existing code, do NOT replace):
-1. ADD endpoint-specific validation rules to ResponseValidator
-2. ADD schema-based response validation methods
-3. ADD business logic validation helpers
-4. ADD response data integrity checks
-5. ADD performance threshold validation to PerformanceMonitor
+Generate 2-4 NEW validation methods specific to these endpoint patterns.
+Focus on business logic validation.
 
-⚠️ **VALIDATION CHECK**: Your output MUST contain:
-1. `class ResponseValidator` - The response validation class
-2. `class RequestLogger` - The request logging class
-3. `class PerformanceMonitor` - The performance monitoring class
-4. `class DataManager` - The data management class
-5. ALL existing methods from each class
+Example output format:
+<code>
+def validate_user_response(self, response: dict) -> bool:
+    """Validate user endpoint response structure."""
+    required_fields = ["id", "email", "created_at"]
+    return all(field in response for field in required_fields)
 
-Return the COMPLETE enhanced Python file with ALL existing classes preserved and enhanced.
+def validate_pagination(self, response: dict) -> bool:
+    """Validate paginated response structure."""
+    return "items" in response and "total" in response
+</code>
 
-**Format**: Return ONLY the complete Python code wrapped in <code></code> tags with NO explanations outside the tags.
+Output ONLY new method definitions wrapped in <code></code> tags.
+Do NOT include imports, class definitions, or existing methods.

--- a/src/devdox_ai_locust/prompt/validation.j2
+++ b/src/devdox_ai_locust/prompt/validation.j2
@@ -1,31 +1,23 @@
-Generate ONLY NEW METHODS to add to the existing ResponseValidator class.
+You are enhancing utility classes for Locust load testing validation.
 
-DO NOT rewrite existing classes. DO NOT include class definitions.
-ONLY output new method definitions that can be added.
+{% if constraints %}
+{{ constraints }}
+{% endif %}
 
-The existing classes already have these methods (DO NOT recreate them):
-- ResponseValidator: validate_response(), validate_status_code(), validate_json_structure()
-- RequestLogger: log_request(), log_response()
-- PerformanceMonitor: record_metric(), get_statistics()
-- DataManager: store_data(), get_data()
+**EXISTING CODE**:
+```python
+{{base_content}}
+```
 
 Validation Patterns Needed:
 {{ validation_patterns }}
 
-Generate 2-4 NEW validation methods specific to these endpoint patterns.
-Focus on business logic validation.
+**YOUR TASK**:
+Enhance this file by ADDING new validation capabilities. You may:
+- ADD new validation methods to ResponseValidator
+- ADD new logging methods to RequestLogger
+- ADD new monitoring methods to PerformanceMonitor
+- IMPROVE existing method implementations (keep their signatures!)
 
-Example output format:
-<code>
-def validate_user_response(self, response: dict) -> bool:
-    """Validate user endpoint response structure."""
-    required_fields = ["id", "email", "created_at"]
-    return all(field in response for field in required_fields)
-
-def validate_pagination(self, response: dict) -> bool:
-    """Validate paginated response structure."""
-    return "items" in response and "total" in response
-</code>
-
-Output ONLY new method definitions wrapped in <code></code> tags.
-Do NOT include imports, class definitions, or existing methods.
+Output the COMPLETE enhanced Python file wrapped in <code></code> tags.
+Remember: Protected symbols MUST remain in the output with unchanged signatures.

--- a/src/devdox_ai_locust/prompt/workflow.j2
+++ b/src/devdox_ai_locust/prompt/workflow.j2
@@ -26,11 +26,10 @@ else:
 **CRITICAL: Authentication Method Implementation**
 
 **CRITICAL: DO NOT INVENT AUTHENTICATION ENDPOINTS!**
-- ONLY implement login_and_get_token() if a login endpoint EXISTS in auth_endpoints below
-- ONLY implement logout_session() if a logout endpoint EXISTS in auth_endpoints below
-- If auth_endpoints is empty or has no login/logout endpoints, DO NOT create these methods
-- Use the EXACT endpoint path from auth_endpoints, never invent paths like "/api/v1/login" or "/api/v1/logout"
-- If no authentication endpoints exist, skip authentication entirely and use config.api_key for authorization
+- ONLY use authentication endpoints that are EXPLICITLY listed in auth_endpoints below
+- Use the EXACT endpoint paths from auth_endpoints (e.g., /auth/token, /oauth/authorize, /session, /authenticate, etc.)
+- Authentication endpoints may have various names - use whatever is in auth_endpoints, not just "/login" or "/logout"
+- If auth_endpoints is empty, skip endpoint-based authentication and use config.api_key for authorization instead
 
 IMPORTANT: `login_and_get_token` and `logout_session` are NOT defined in parent classes (BaseTaskMethods or SequentialTaskSet).
 These methods must be defined in the workflow class itself and called via `self`, NOT `super()`.
@@ -75,8 +74,9 @@ def login_and_get_token(self):
 
 # WRONG #3 - inventing endpoints that don't exist in OpenAPI spec!
 def login_and_get_token(self):
-    # DO NOT use endpoints unless they exist in auth_endpoints!
-    with self.client.post("/api/v1/login", ...)  # WRONG if not in spec!
+    # DO NOT invent endpoints - use ONLY what's in auth_endpoints!
+    # If auth_endpoints has "/auth/token", use that, not "/api/v1/login"
+    with self.client.post("/api/v1/login", ...)  # WRONG if this path isn't in auth_endpoints!
 ```
 {% endif %}
 TASK: Enhance this Locust workflow file with COMPREHENSIVE test scenarios and LOGICAL TASK ORDERING.

--- a/src/devdox_ai_locust/prompt/workflow.j2
+++ b/src/devdox_ai_locust/prompt/workflow.j2
@@ -1,5 +1,5 @@
 CRITICAL CONSTRAINTS: Only use endpoints that exist in the OpenAPI specification. DO NOT create, modify, or reference any endpoints not listed below.
-{if auth_endpoints}
+{% if auth_endpoints %}
 **CRITICAL: Authentication Method Reuse**
 
 Before generating ANY authentication methods:
@@ -14,11 +14,11 @@ Before generating ANY authentication methods:
 3. **IF base_workflow lacks auth methods AND auth endpoints exist**:
    - **ONLY THEN** generate new auth methods
 """
-{endif}
+{% endif %}
 TASK: Enhance this Locust workflow file with COMPREHENSIVE test scenarios and LOGICAL TASK ORDERING.
 STRICT REQUIREMENTS:
         1. ONLY use these exact API endpoints from OpenAPI spec:
-        {{  grouped_enpoints }}
+        {{ grouped_endpoints }}
 
          2. Authentication Management:
         {{ auth_endpoints }}

--- a/src/devdox_ai_locust/prompt/workflow.j2
+++ b/src/devdox_ai_locust/prompt/workflow.j2
@@ -1,19 +1,40 @@
 CRITICAL CONSTRAINTS: Only use endpoints that exist in the OpenAPI specification. DO NOT create, modify, or reference any endpoints not listed below.
 {% if auth_endpoints %}
-**CRITICAL: Authentication Method Reuse**
+**CRITICAL: Authentication Method Implementation**
 
-Before generating ANY authentication methods:
+IMPORTANT: `login_and_get_token` and `logout_session` are NOT defined in parent classes (BaseTaskMethods or SequentialTaskSet).
+These methods must be defined in the workflow class itself and called via `self`, NOT `super()`.
 
-1. **Check base_workflow.py content** to detect existing auth methods to import and call them instead of generating new ones of endpoints
+Before generating authentication methods:
 
-2. **IF base_workflow has auth methods and the sent file is not base_workflow.py **:
-   - **DO NOT** generate new login/logout methods
-   - **INHERIT** from base workflow class
-   - **CALL** super().method_name() in on_start/on_stop
+1. **Check if the current workflow file already defines login/logout methods**
 
-3. **IF base_workflow lacks auth methods AND auth endpoints exist**:
-   - **ONLY THEN** generate new auth methods
-"""
+2. **IF the workflow class already defines auth methods**:
+   - Use `self.login_and_get_token()` in on_start()
+   - Use `self.logout_session()` in on_stop()
+   - NEVER call `super().login_and_get_token()` - this method does not exist in parent classes
+
+3. **IF the workflow class lacks auth methods AND auth endpoints exist**:
+   - ADD login_and_get_token() and logout_session() methods to the workflow class
+   - Call them via `self` in on_start/on_stop
+
+CORRECT PATTERN:
+```python
+def on_start(self):
+    super().on_start()  # Only calls BaseTaskMethods.on_start()
+    self.login_and_get_token()  # Call via self, NOT super()
+
+def on_stop(self):
+    self.logout_session()  # Call via self, NOT super()
+    super().on_stop()
+```
+
+WRONG PATTERN (DO NOT USE):
+```python
+# WRONG - login_and_get_token does not exist in parent classes
+if hasattr(super(), 'login_and_get_token'):
+    super().login_and_get_token()
+```
 {% endif %}
 TASK: Enhance this Locust workflow file with COMPREHENSIVE test scenarios and LOGICAL TASK ORDERING.
 STRICT REQUIREMENTS:
@@ -22,17 +43,17 @@ STRICT REQUIREMENTS:
 
          2. Authentication Management:
         {{ auth_endpoints }}
-        Since BASE WORKFLOW: {{base_workflow}} with path base_workflow.py is provided, use existing authentication methods from base_workflow:
 
-            - Check if base_workflow contains login/authentication methods and USE those instead of creating new ones
+        IMPORTANT: BaseTaskMethods (from base_workflow.py) does NOT define login_and_get_token or logout_session.
+        These methods must be defined in each workflow class that needs authentication.
 
-            - If auth endpoints exist but no base_workflow auth methods, then ADD login task at beginning
+            - If auth endpoints exist, define login_and_get_token() and logout_session() in the workflow class
 
-            - Implement 401 retry logic using base_workflow authentication methods when available
+            - Call these methods via `self` (e.g., self.login_and_get_token()), NOT via super()
 
-            - If base_workflow has logout methods, use those; otherwise ADD logout task if logout endpoints exist
+            - Use handle_401_retry() from BaseTaskMethods for automatic re-authentication on 401 responses
 
-            - AVOID creating redundant authentication tasks if base_workflow already handles auth
+            - NEVER call super().login_and_get_token() - this method does not exist in parent classes
         3. PRESERVE EXISTING STRUCTURE:
            - Keep ALL existing @task methods, classes, and functions
            - DO NOT remove any existing functionality
@@ -498,12 +519,13 @@ STRICT REQUIREMENTS:
     19. **BASE WORKFLOW INTEGRATION**:
 
         Since base_workflow.py is provided, maximize reuse and avoid duplication:
-        **A. Authentication Reuse:**
+        **A. Authentication Implementation:**
 
-        - Inspect base_workflow for existing login/authenticate/logout methods
-        - Use base_workflow auth methods in on_start() if available
-        - Only create new auth tasks if base_workflow lacks auth and endpoints exist
-        - Inherit authentication headers/tokens from base_workflow methods
+        IMPORTANT: BaseTaskMethods does NOT define login_and_get_token or logout_session.
+        - Define login_and_get_token() and logout_session() in YOUR workflow class
+        - Call via self.login_and_get_token(), NOT super().login_and_get_token()
+        - Use handle_401_retry() from BaseTaskMethods for 401 retry logic
+        - Store auth tokens in self.auth_token and update self.default_headers
 
 
 
@@ -532,17 +554,14 @@ STRICT REQUIREMENTS:
            - Store document IDs for API operations
     {% endif %}
 
-    **Authentication Phase(using base_workflow methods when available):**
+    **Authentication Phase:**
+    NOTE: login_and_get_token() and logout_session() must be defined in the workflow class itself.
+    Call via self.login_and_get_token() in on_start(), NOT super().login_and_get_token().
 
-    - Use existing base_workflow.login() method if available (weight: 10)
-
-    - If no base_workflow auth, then add_login_valid_credentials (weight: 10)
-
-    - login_invalid_credentials (weight: 3) - expect 401 (only if creating new auth)
-
-    - login_malformed_request (weight: 2) - expect 400 (only if creating new auth)
-
-    Note: Method names will be dynamically extracted from base_workflow.py content using regex patterns
+    - Define login_and_get_token() method in workflow class
+    - Call self.login_and_get_token() in on_start() (weight: 10)
+    - login_invalid_credentials (weight: 3) - expect 401
+    - login_malformed_request (weight: 2) - expect 400
     **Creation Phase:**
     - add_reseller_valid_complete_data (weight: 10) → store reseller_id
     - add_reseller_minimal_data (weight: 8) → store reseller_id
@@ -585,10 +604,13 @@ STRICT REQUIREMENTS:
             - Verify database consistency after all operations
     {% endif %}
 
-    **Logout Phase (using base_workflow methods when available):**
-    - Use existing base_workflow.logout() method if available (weight: 5)
-    - If no base_workflow logout, then add logout_valid_session (weight: 5)
-    - logout_expired_session (weight: 2) - expect 401 (only if creating new logout)
+    **Logout Phase:**
+    NOTE: logout_session() must be defined in the workflow class itself.
+    Call via self.logout_session() in on_stop(), NOT super().logout_session().
+
+    - Define logout_session() method in workflow class
+    - Call self.logout_session() in on_stop() (weight: 5)
+    - logout_expired_session (weight: 2) - expect 401
 
     VALIDATION RULES:
         - Every @task method must correspond to an actual OpenAPI endpoint

--- a/src/devdox_ai_locust/prompt/workflow.j2
+++ b/src/devdox_ai_locust/prompt/workflow.j2
@@ -1,6 +1,36 @@
 CRITICAL CONSTRAINTS: Only use endpoints that exist in the OpenAPI specification. DO NOT create, modify, or reference any endpoints not listed below.
+
+**CRITICAL: catch_response=True REQUIRES with-block**
+When using `catch_response=True`, you MUST use a `with` statement. The `response.success()` and `response.failure()` methods are ONLY valid inside the context manager.
+
+CORRECT PATTERN:
+```python
+with self.client.post("/endpoint", json=data, catch_response=True) as response:
+    if response.status_code == 200:
+        response.success()  # Valid - inside with-block
+    else:
+        response.failure("Error message")  # Valid - inside with-block
+```
+
+WRONG PATTERN (CAUSES RUNTIME ERROR):
+```python
+# WRONG - will cause LocustError: "Tried to set status on a request that has not yet been made"
+response = self.client.post("/endpoint", json=data, catch_response=True)
+if response.status_code == 200:
+    response.success()  # RUNTIME ERROR - outside with-block!
+else:
+    response.failure("Error message")  # RUNTIME ERROR - outside with-block!
+```
+
 {% if auth_endpoints %}
 **CRITICAL: Authentication Method Implementation**
+
+**CRITICAL: DO NOT INVENT AUTHENTICATION ENDPOINTS!**
+- ONLY implement login_and_get_token() if a login endpoint EXISTS in auth_endpoints below
+- ONLY implement logout_session() if a logout endpoint EXISTS in auth_endpoints below
+- If auth_endpoints is empty or has no login/logout endpoints, DO NOT create these methods
+- Use the EXACT endpoint path from auth_endpoints, never invent paths like "/api/v1/login" or "/api/v1/logout"
+- If no authentication endpoints exist, skip authentication entirely and use config.api_key for authorization
 
 IMPORTANT: `login_and_get_token` and `logout_session` are NOT defined in parent classes (BaseTaskMethods or SequentialTaskSet).
 These methods must be defined in the workflow class itself and called via `self`, NOT `super()`.
@@ -29,11 +59,24 @@ def on_stop(self):
     super().on_stop()
 ```
 
-WRONG PATTERN (DO NOT USE):
+WRONG PATTERNS (DO NOT USE):
 ```python
-# WRONG - login_and_get_token does not exist in parent classes
+# WRONG #1 - login_and_get_token does not exist in parent classes
 if hasattr(super(), 'login_and_get_token'):
     super().login_and_get_token()
+
+# WRONG #2 - catch_response without with-block causes runtime error!
+def login_and_get_token(self):
+    response = self.client.post("/login", json=data, catch_response=True)
+    if response.status_code == 200:
+        response.success()  # RUNTIME ERROR - must be inside 'with' block!
+    else:
+        response.failure("Failed")  # RUNTIME ERROR - must be inside 'with' block!
+
+# WRONG #3 - inventing endpoints that don't exist in OpenAPI spec!
+def login_and_get_token(self):
+    # DO NOT use endpoints unless they exist in auth_endpoints!
+    with self.client.post("/api/v1/login", ...)  # WRONG if not in spec!
 ```
 {% endif %}
 TASK: Enhance this Locust workflow file with COMPREHENSIVE test scenarios and LOGICAL TASK ORDERING.
@@ -120,6 +163,11 @@ STRICT REQUIREMENTS:
        - Expect 422 Validation Error scenarios (weight: 3)
 
     7. AUTHENTICATION INTEGRATION STRATEGY:
+
+           **CRITICAL: Only implement authentication if actual login/logout endpoints exist in auth_endpoints!**
+           - Do NOT invent authentication endpoints like "/api/v1/login" or "/login"
+           - If auth_endpoints is empty, use config.api_key for authorization instead
+           - Always use `with` block when using catch_response=True
 
            Since base_workflow.py is provided, implement smart authentication handling to setup_authentication method to send headers with valid credentials and in  case returning 401 to login with new credentials:
 

--- a/src/devdox_ai_locust/schemas/processing_result.py
+++ b/src/devdox_ai_locust/schemas/processing_result.py
@@ -1,24 +1,73 @@
-from pydantic import BaseModel, field_validator, ValidationInfo
+from pydantic import BaseModel, field_validator, model_validator
 from typing import Optional, Type
+from pathlib import Path
 
 
 class SwaggerProcessingRequest(BaseModel):
+    """
+    Request model for processing Swagger/OpenAPI specifications.
+
+    Exactly one of swagger_url or swagger_path must be provided.
+    - swagger_url: HTTP(S) URL to fetch the schema from
+    - swagger_path: Local filesystem path to read the schema from
+    """
     swagger_url: Optional[str] = None
+    swagger_path: Optional[str] = None
 
     @field_validator("swagger_url", mode="before")
     @classmethod
-    def coerce_to_string(
+    def coerce_url_to_string(
         cls: Type["SwaggerProcessingRequest"], v: Optional[str]
     ) -> Optional[str]:
         if v is None:
             return v
-        return str(v)
+        return str(v).strip()
 
-    @field_validator("swagger_url")
+    @field_validator("swagger_path", mode="before")
     @classmethod
-    def validate_url_when_source_is_url(
-        cls: Type["SwaggerProcessingRequest"], v: Optional[str], info: ValidationInfo
+    def coerce_path_to_string(
+        cls: Type["SwaggerProcessingRequest"], v: Optional[str]
     ) -> Optional[str]:
-        if info.data.get("swagger_source") == "url" and not v:
-            raise ValueError("swagger_url is required when source is url")
-        return v
+        if v is None:
+            return v
+        # Convert Path objects to string
+        if isinstance(v, Path):
+            return str(v)
+        return str(v).strip()
+
+    @model_validator(mode="after")
+    def validate_exactly_one_source(self) -> "SwaggerProcessingRequest":
+        """Ensure exactly one of swagger_url or swagger_path is provided"""
+        has_url = self.swagger_url is not None and self.swagger_url.strip() != ""
+        has_path = self.swagger_path is not None and self.swagger_path.strip() != ""
+
+        if has_url and has_path:
+            raise ValueError(
+                "Cannot specify both swagger_url and swagger_path. "
+                "Please provide only one source."
+            )
+
+        if not has_url and not has_path:
+            raise ValueError(
+                "Must specify either swagger_url or swagger_path. "
+                "No source provided."
+            )
+
+        return self
+
+    @property
+    def is_url_source(self) -> bool:
+        """Check if the source is a URL"""
+        return self.swagger_url is not None and self.swagger_url.strip() != ""
+
+    @property
+    def is_file_source(self) -> bool:
+        """Check if the source is a file path"""
+        return self.swagger_path is not None and self.swagger_path.strip() != ""
+
+    @property
+    def source_location(self) -> str:
+        """Get the source location (URL or path)"""
+        if self.is_url_source:
+            return self.swagger_url
+        return self.swagger_path

--- a/src/devdox_ai_locust/templates/base_workflow.py.j2
+++ b/src/devdox_ai_locust/templates/base_workflow.py.j2
@@ -96,10 +96,8 @@ class BaseTaskMethods:
 
     def on_stop(self):
         """Cleanup when user stops"""
-        if hasattr(self, 'request_count'):
-            logger.info(f"TaskSet {self.__class__.__name__} stopped after {self.request_count} requests")
-        else:
-            logger.info(f"TaskSet {self.__class__.__name__} stopped after {self.request_count} requests")
+        request_count = getattr(self, 'request_count', 0)
+        logger.info(f"TaskSet {self.__class__.__name__} stopped after {request_count} requests")
 
     def _setup_authentication(self):
         """Setup authentication (override in subclasses if needed)"""

--- a/src/devdox_ai_locust/templates/base_workflow.py.j2
+++ b/src/devdox_ai_locust/templates/base_workflow.py.j2
@@ -1,21 +1,25 @@
 """
-Locust performance tests for {{api_info.title}}
+Locust performance tests for {{ api_info.title }}
 
 API Information:
-- Title: {{api_info.title}}
-- Version: {{api_info.version}}
-- Base URL: {{api_info.base_url}}
+- Title: {{ api_info.title }}
+- Version: {{ api_info.version }}
+- Base URL: {{ api_info.base_url }}
 """
 
 from locust import HttpUser, task, between, events, SequentialTaskSet
 import json
 import logging
-from typing import Dict, Any, Optional, List
+from dataclasses import dataclass
+from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from urllib.parse import urljoin
 
 from test_data import TestDataGenerator
 from utils import ResponseValidator, RequestLogger, PerformanceMonitor
 from config import LoadTestConfig
+
+if TYPE_CHECKING:
+    from locust.clients import HttpSession
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -26,6 +30,44 @@ config = LoadTestConfig()
 data_generator = TestDataGenerator()
 response_validator = ResponseValidator()
 performance_monitor = PerformanceMonitor()
+
+
+@dataclass
+class ResponseEnvelope:
+    """
+    Envelope for HTTP response data with status code for proper error handling.
+
+    This provides a consistent interface for checking response status codes
+    in retry logic (like handle_401_retry) without relying on the raw Locust
+    response object which is only available inside the context manager.
+    """
+    status_code: int
+    payload: Optional[Dict[str, Any]] = None
+    text: Optional[str] = None
+    ok: bool = False
+    error: Optional[str] = None
+
+    @classmethod
+    def success(cls, status_code: int, payload: Optional[Dict] = None, text: str = "") -> "ResponseEnvelope":
+        """Create a successful response envelope"""
+        return cls(
+            status_code=status_code,
+            payload=payload,
+            text=text,
+            ok=status_code < 400,
+            error=None
+        )
+
+    @classmethod
+    def failure(cls, status_code: int, error: str, text: str = "") -> "ResponseEnvelope":
+        """Create a failed response envelope"""
+        return cls(
+            status_code=status_code,
+            payload=None,
+            text=text,
+            ok=False,
+            error=error
+        )
 
 
 class BaseTaskMethods:
@@ -78,8 +120,17 @@ class BaseTaskMethods:
         if self.auth_token:
             self.default_headers["Authorization"] = f"Bearer {self.auth_token}"
 
-    def make_request(self, method: str, path: str, **kwargs) -> Optional[Dict]:
-        """Make HTTP request with logging, validation, and monitoring"""
+    # Type hint for IDE support - client is provided by SequentialTaskSet at runtime
+    client: "HttpSession"
+
+    def make_request(self, method: str, path: str, **kwargs) -> Optional[ResponseEnvelope]:
+        """
+        Make HTTP request with logging, validation, and monitoring.
+
+        Returns:
+            ResponseEnvelope with status_code and payload for proper error handling,
+            or None if the request completely failed.
+        """
         self._initialize_attributes()
         self.request_count += 1
 
@@ -105,32 +156,64 @@ class BaseTaskMethods:
                 catch_response=True,
                 **kwargs
             ) as response:
+                status_code = response.status_code
+                text = response.text if hasattr(response, 'text') else ""
+
                 # Validate and monitor
                 is_valid = response_validator.validate_response(response, method, path)
                 performance_monitor.record_response(response, method, path)
 
                 if not is_valid:
                     response.failure(f"Response validation failed for {method} {path}")
-                    return None
+                    return ResponseEnvelope.failure(
+                        status_code=status_code,
+                        error=f"Validation failed for {method} {path}",
+                        text=text
+                    )
 
                 try:
-                    return response.json() if response.content else None
+                    payload = response.json() if response.content else None
+                    return ResponseEnvelope.success(
+                        status_code=status_code,
+                        payload=payload,
+                        text=text
+                    )
                 except json.JSONDecodeError:
-                    if response.status_code < 400:
-                        return {"raw_content": response.text}
+                    if status_code < 400:
+                        return ResponseEnvelope.success(
+                            status_code=status_code,
+                            payload={"raw_content": text},
+                            text=text
+                        )
                     response.failure(f"Invalid JSON response for {method} {path}")
-                    return None
+                    return ResponseEnvelope.failure(
+                        status_code=status_code,
+                        error=f"Invalid JSON for {method} {path}",
+                        text=text
+                    )
 
         except Exception as e:
             logger.error(f"Request failed {method} {path}: {e}")
             return None
 
-    def _store_response_data(self, method_name: str, data: Dict):
-        """Store response data for future requests"""
+    def _store_response_data(self, method_name: str, data):
+        """
+        Store response data for future requests.
+
+        Args:
+            method_name: Key to store the data under
+            data: Either a ResponseEnvelope (extracts payload) or a Dict
+        """
         if not hasattr(self, 'user_data'):
             self.user_data = {}
         if data:
-            self.user_data[method_name] = data
+            # Handle ResponseEnvelope - extract payload
+            if isinstance(data, ResponseEnvelope):
+                if data.payload:
+                    self.user_data[method_name] = data.payload
+            else:
+                # Handle raw dict
+                self.user_data[method_name] = data
 
     def _get_stored_data(self, method_name: str, key: str = None):
         """Retrieve stored response data from previous requests"""
@@ -138,6 +221,42 @@ class BaseTaskMethods:
         if stored_data and key:
             return stored_data.get(key)
         return stored_data
+
+    def handle_401_retry(self, method: str, path: str, **kwargs) -> Optional[ResponseEnvelope]:
+        """
+        Handle 401 responses with automatic re-authentication.
+
+        Makes a request and if it returns 401 Unauthorized, attempts to
+        re-authenticate and retry the request once.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            path: API path
+            **kwargs: Additional request arguments
+
+        Returns:
+            ResponseEnvelope with status_code and payload, or None on complete failure
+        """
+        response = self.make_request(method, path, **kwargs)
+
+        if response is None:
+            return None
+
+        # Check for 401 and retry with re-authentication
+        if response.status_code == 401:
+            logger.warning(f"401 Unauthorized - re-authenticating and retrying {method} {path}")
+
+            # Call login method if available
+            if hasattr(self, 'login_and_get_token'):
+                self.login_and_get_token()
+            elif hasattr(self, '_setup_authentication'):
+                self._setup_authentication()
+                self._setup_headers()
+
+            # Retry the request
+            response = self.make_request(method, path, **kwargs)
+
+        return response
 
 
 class BaseAPIUser(HttpUser):

--- a/src/devdox_ai_locust/templates/endpoint_template.py.j2
+++ b/src/devdox_ai_locust/templates/endpoint_template.py.j2
@@ -1,5 +1,5 @@
 """
-Locust performance tests for {{group}}
+Locust performance tests for {{ group }}
 Generated on: {{ generated_at }}
 
 API Information:
@@ -11,6 +11,9 @@ API Information:
 from locust import HttpUser, task, between, events, SequentialTaskSet
 from locust.runners import MasterRunner
 import logging
+import json
+from typing import Dict, Any, Optional, List
+from urllib.parse import urljoin
 
 from test_data import TestDataGenerator
 from utils import ResponseValidator, RequestLogger, PerformanceMonitor
@@ -28,7 +31,12 @@ response_validator = ResponseValidator()
 performance_monitor = PerformanceMonitor()
 
 
-class {{ group | capitalize }}TaskMethods(SequentialTaskSet, BaseTaskMethods):
-    """Mixin class containing all API task methods"""
+class {{ task_methods_class_name }}(SequentialTaskSet, BaseTaskMethods):
+    """Task methods for {{ group }} workflow"""
 
-    {{task_methods_content}}
+    {{ task_methods_content }}
+
+
+class {{ api_user_class_name }}(BaseAPIUser):
+    """API User for {{ group }} workflow"""
+    tasks = [{{ task_methods_class_name }}]

--- a/src/devdox_ai_locust/templates/fallback_locust.py.j2
+++ b/src/devdox_ai_locust/templates/fallback_locust.py.j2
@@ -1,5 +1,5 @@
 """
-    Fallback Locust test file for {api_info.get('title', 'API')}
+Fallback Locust test file for {{ api_info.get('title', 'API') }}
 """
 
 from locust import HttpUser, task, between
@@ -9,17 +9,17 @@ logger = logging.getLogger(__name__)
 
 
 class BasicAPIUser(HttpUser):
-        wait_time = between(1, 5)
+    wait_time = between(1, 5)
 
-        @task(1)
-        def health_check(self):
-            """Basic health check"""
-            with self.client.get("/health", catch_response=True) as response:
-                if response.status_code == 200:
-                    response.success()
-                else:
-                    response.failure(f"Health check failed: {{response.status_code}}")
+    @task(1)
+    def health_check(self):
+        """Basic health check"""
+        with self.client.get("/health", catch_response=True) as response:
+            if response.status_code == 200:
+                response.success()
+            else:
+                {% raw %}response.failure(f"Health check failed: {response.status_code}"){% endraw %}
 
 
 if __name__ == "__main__":
-    print("Running fallback Locust test for {{api_info.title}}")
+    print("Running fallback Locust test for {{ api_info.get('title', 'API') }}")

--- a/src/devdox_ai_locust/templates/locust.py.j2
+++ b/src/devdox_ai_locust/templates/locust.py.j2
@@ -6,16 +6,17 @@ API Information:
 - Title: {{ api_info.get('title', 'Unknown') }}
 - Version: {{ api_info.get('version', 'Unknown') }}
 - Base URL: {{ api_info.get('base_url', 'http://localhost') }}
+
+This is the main orchestrator that coordinates all workflow TaskSets.
+Individual workflow logic is defined in the workflows/ directory.
 """
 
 from locust import HttpUser, task, between, events
 from locust.runners import MasterRunner
-import json
-import random
 import logging
 from typing import Dict, Any, Optional
-from urllib.parse import urljoin
-from workflows.base_workflow import BaseAPIUser
+
+from workflows.base_workflow import BaseAPIUser, BaseTaskMethods
 {{ import_group_tasks }}
 
 from test_data import TestDataGenerator
@@ -31,14 +32,6 @@ config = LoadTestConfig()
 data_generator = TestDataGenerator()
 response_validator = ResponseValidator()
 performance_monitor = PerformanceMonitor()
-
-
-class APITaskMethods:
-    """Mixin class containing all API task methods"""
-
-    {{ task_methods_content }}
-
-    tasks = {{ tasks_str }}
 
 
 {{ generated_task_classes }}

--- a/src/devdox_ai_locust/templates/test_data.py.j2
+++ b/src/devdox_ai_locust/templates/test_data.py.j2
@@ -73,6 +73,24 @@ class TestDataGenerator:
 
             if '$ref' in prop_schema:
                 result[prop_name] = self._handle_reference(prop_schema['$ref'])
+            else:
+                # Handle non-reference properties by recursing or generating based on type
+                prop_type = prop_schema.get('type', 'string')
+                if prop_type == 'object':
+                    result[prop_name] = self.generate_json_data(prop_schema)
+                elif prop_type == 'array':
+                    result[prop_name] = self._generate_array_data(prop_schema)
+                elif prop_type == 'string':
+                    result[prop_name] = self._generate_string_value(prop_schema, prop_name)
+                elif prop_type == 'integer':
+                    result[prop_name] = self._generate_integer_value(prop_schema)
+                elif prop_type == 'number':
+                    result[prop_name] = self._generate_number_value(prop_schema)
+                elif prop_type == 'boolean':
+                    result[prop_name] = self._generate_boolean_value(prop_schema)
+                else:
+                    # Fallback: use property name pattern matching
+                    result[prop_name] = self._generate_by_name_pattern(prop_name)
 
         return result
 

--- a/src/devdox_ai_locust/templates/user_classes.py.j2
+++ b/src/devdox_ai_locust/templates/user_classes.py.j2
@@ -1,30 +1,33 @@
-class LightUser(BaseAPIUser, BaseTaskMethods):
+class LightUser(BaseAPIUser):
     """Light user with occasional API usage patterns"""
 
     weight = 3
     wait_time = between(3, 8)  # Longer wait times
+    tasks = {{ tasks_list }}
 
     def on_start(self):
         super().on_start()
         self.user_type = "light"
 
 
-class RegularUser(BaseAPIUser, BaseTaskMethods):
+class RegularUser(BaseAPIUser):
     """Regular user with normal API usage patterns"""
 
     weight = 4
     wait_time = between(1, 4)  # Moderate wait times
+    tasks = {{ tasks_list }}
 
     def on_start(self):
         super().on_start()
         self.user_type = "regular"
 
 
-class PowerUser(BaseAPIUser, BaseTaskMethods):
+class PowerUser(BaseAPIUser):
     """Power user with heavy API usage patterns"""
 
     weight = 3
     wait_time = between(0.5, 2)  # Shorter wait times
+    tasks = {{ tasks_list }}
 
     def on_start(self):
         super().on_start()

--- a/src/devdox_ai_locust/utils/file_creation.py
+++ b/src/devdox_ai_locust/utils/file_creation.py
@@ -34,15 +34,30 @@ class SafeFileCreator:
         self.config = config or FileCreationConfig()
 
     def _sanitize_filename(self, filename: str) -> str:
-        """Sanitize filename to prevent security issues"""
+        """Sanitize filename to prevent security issues and ensure valid Python module names"""
 
         # Remove directory components
         clean_name = os.path.basename(filename).lower()
 
         # Remove dangerous characters
         clean_name = re.sub(r'[<>:"/\\|?*]', "", clean_name)
-        # Replace spaces with underscores
-        clean_name = clean_name.replace("- ", "_")
+
+        # Replace spaces, dashes, and other separators with underscores
+        clean_name = re.sub(r'[\s\-]+', '_', clean_name)
+
+        # Remove any remaining non-word characters except dots and underscores
+        # Keep dots for file extensions
+        name_part, ext = os.path.splitext(clean_name)
+        name_part = re.sub(r'[^\w]', '_', name_part)
+
+        # Remove consecutive underscores
+        name_part = re.sub(r'_+', '_', name_part)
+
+        # Strip leading/trailing underscores from name part
+        name_part = name_part.strip('_')
+
+        # Reconstruct with extension
+        clean_name = f"{name_part}{ext}" if name_part else ext
 
         # Ensure reasonable length
         if len(clean_name) > 255:

--- a/src/devdox_ai_locust/utils/naming.py
+++ b/src/devdox_ai_locust/utils/naming.py
@@ -1,0 +1,289 @@
+"""
+Centralized Naming Strategy Module
+
+Provides consistent naming transformations for:
+- Workflow module names (python-safe snake_case)
+- Workflow filenames
+- TaskMethods class names (PascalCase)
+- Method names from endpoints
+- Path parameter variable names
+
+All naming decisions should flow through this module to ensure consistency
+between generated imports, class names, and file names.
+"""
+
+import re
+import keyword
+from typing import Optional, Set, Protocol
+from dataclasses import dataclass, field
+
+
+class NamingStrategy(Protocol):
+    """Protocol for naming strategy implementations"""
+
+    def to_workflow_module(self, group_label: str) -> str:
+        """Convert group label to workflow module name (e.g., 'authentication')"""
+        ...
+
+    def to_workflow_filename(self, group_label: str) -> str:
+        """Convert group label to workflow filename (e.g., 'authentication_workflow.py')"""
+        ...
+
+    def to_task_methods_class(self, group_label: str) -> str:
+        """Convert group label to TaskMethods class name (e.g., 'AuthenticationTaskMethods')"""
+        ...
+
+    def to_method_name(
+        self, operation_id: Optional[str], method: str, path: str
+    ) -> str:
+        """Generate valid Python method name from endpoint info"""
+        ...
+
+    def to_param_var(self, raw_param_name: str) -> str:
+        """Convert raw parameter name to valid Python variable name"""
+        ...
+
+
+@dataclass
+class DefaultNamingStrategy:
+    """
+    Default implementation of naming strategy.
+
+    Ensures all generated names are valid Python identifiers and
+    consistent across the codebase.
+    """
+
+    _used_method_names: Set[str] = field(default_factory=set)
+
+    def _sanitize_identifier(self, name: str) -> str:
+        """
+        Convert any string to a valid Python identifier.
+
+        - Replaces non-alphanumeric characters with underscores
+        - Ensures starts with letter or underscore
+        - Removes consecutive underscores
+        - Converts to lowercase
+        """
+        if not name:
+            return "unnamed"
+
+        # Replace all non-word characters with underscores
+        sanitized = re.sub(r'[^\w]', '_', name)
+
+        # Remove consecutive underscores
+        sanitized = re.sub(r'_+', '_', sanitized)
+
+        # Strip leading/trailing underscores
+        sanitized = sanitized.strip('_')
+
+        # Convert to lowercase
+        sanitized = sanitized.lower()
+
+        # Ensure it starts with a letter or underscore
+        if sanitized and sanitized[0].isdigit():
+            sanitized = f"n_{sanitized}"
+
+        # Handle empty result
+        if not sanitized:
+            sanitized = "unnamed"
+
+        # Handle Python keywords
+        if keyword.iskeyword(sanitized):
+            sanitized = f"{sanitized}_"
+
+        return sanitized
+
+    def _to_pascal_case(self, name: str) -> str:
+        """
+        Convert a string to PascalCase.
+
+        Examples:
+            'user_management' -> 'UserManagement'
+            'api-key' -> 'ApiKey'
+            'git_tokens' -> 'GitTokens'
+        """
+        if not name:
+            return "Unnamed"
+
+        # First sanitize to get consistent word boundaries
+        sanitized = re.sub(r'[^\w]', '_', name)
+
+        # Split on underscores and capitalize each word
+        words = [w for w in sanitized.split('_') if w]
+
+        if not words:
+            return "Unnamed"
+
+        # Capitalize each word
+        pascal = ''.join(word.capitalize() for word in words)
+
+        # Ensure starts with letter
+        if pascal and pascal[0].isdigit():
+            pascal = f"N{pascal}"
+
+        return pascal
+
+    def to_workflow_module(self, group_label: str) -> str:
+        """
+        Convert group label to workflow module name.
+
+        Examples:
+            'User Management' -> 'user_management'
+            'api-key' -> 'api_key'
+            'GitTokens' -> 'gittokens'
+        """
+        return self._sanitize_identifier(group_label)
+
+    def to_workflow_filename(self, group_label: str) -> str:
+        """
+        Convert group label to workflow filename.
+
+        Examples:
+            'User Management' -> 'user_management_workflow.py'
+            'api-key' -> 'api_key_workflow.py'
+        """
+        module_name = self.to_workflow_module(group_label)
+        return f"{module_name}_workflow.py"
+
+    def to_task_methods_class(self, group_label: str) -> str:
+        """
+        Convert group label to TaskMethods class name.
+
+        Examples:
+            'User Management' -> 'UserManagementTaskMethods'
+            'api-key' -> 'ApiKeyTaskMethods'
+            'authentication' -> 'AuthenticationTaskMethods'
+        """
+        pascal_name = self._to_pascal_case(group_label)
+        return f"{pascal_name}TaskMethods"
+
+    def to_api_user_class(self, group_label: str) -> str:
+        """
+        Convert group label to APIUser class name.
+
+        Examples:
+            'User Management' -> 'UserManagementAPIUser'
+            'api-key' -> 'ApiKeyAPIUser'
+        """
+        pascal_name = self._to_pascal_case(group_label)
+        return f"{pascal_name}APIUser"
+
+    def to_method_name(
+        self,
+        operation_id: Optional[str],
+        method: str,
+        path: str,
+        ensure_unique: bool = True,
+    ) -> str:
+        """
+        Generate valid Python method name from endpoint info.
+
+        Args:
+            operation_id: OpenAPI operationId if available
+            method: HTTP method (GET, POST, etc.)
+            path: API path (/api/v1/users/{id})
+            ensure_unique: If True, appends suffix if name was already used
+
+        Returns:
+            Valid Python method name
+        """
+        if operation_id:
+            base_name = self._sanitize_identifier(operation_id)
+        else:
+            # Generate from method and path
+            path_parts = [
+                part
+                for part in path.split('/')
+                if part and not part.startswith('{')
+            ]
+            base_name = f"{method.lower()}_{'_'.join(path_parts)}"
+            base_name = self._sanitize_identifier(base_name)
+
+        if not base_name:
+            base_name = f"{method.lower()}_endpoint"
+
+        # Ensure uniqueness if requested
+        if ensure_unique:
+            final_name = base_name
+            counter = 2
+            while final_name in self._used_method_names:
+                final_name = f"{base_name}_{counter}"
+                counter += 1
+            self._used_method_names.add(final_name)
+            return final_name
+
+        return base_name
+
+    def to_param_var(self, raw_param_name: str) -> str:
+        """
+        Convert raw parameter name to valid Python variable name.
+
+        Examples:
+            'user-id' -> 'user_id'
+            'api_key' -> 'api_key'
+            'Content-Type' -> 'content_type'
+            '123abc' -> 'n_123abc'
+        """
+        return self._sanitize_identifier(raw_param_name)
+
+    def to_path_with_safe_params(self, path: str, params: list) -> str:
+        """
+        Convert path with parameters to use safe Python variable names.
+
+        Args:
+            path: Original path like '/users/{user-id}/posts/{post-id}'
+            params: List of parameter objects with 'name' attribute
+
+        Returns:
+            Path with sanitized parameter names like '/users/{user_id}/posts/{post_id}'
+        """
+        result = path
+        for param in params:
+            if hasattr(param, 'name') and hasattr(param, 'location'):
+                if param.location.value == 'path':
+                    safe_name = self.to_param_var(param.name)
+                    result = result.replace(f'{{{param.name}}}', f'{{{safe_name}}}')
+        return result
+
+    def reset_used_names(self) -> None:
+        """Reset the set of used method names (call between workflows)"""
+        self._used_method_names.clear()
+
+
+# Global default instance for convenience
+default_naming = DefaultNamingStrategy()
+
+
+def to_workflow_module(group_label: str) -> str:
+    """Convenience function using default naming strategy"""
+    return default_naming.to_workflow_module(group_label)
+
+
+def to_workflow_filename(group_label: str) -> str:
+    """Convenience function using default naming strategy"""
+    return default_naming.to_workflow_filename(group_label)
+
+
+def to_task_methods_class(group_label: str) -> str:
+    """Convenience function using default naming strategy"""
+    return default_naming.to_task_methods_class(group_label)
+
+
+def to_api_user_class(group_label: str) -> str:
+    """Convenience function using default naming strategy"""
+    return default_naming.to_api_user_class(group_label)
+
+
+def to_method_name(
+    operation_id: Optional[str],
+    method: str,
+    path: str,
+    ensure_unique: bool = False,
+) -> str:
+    """Convenience function using default naming strategy"""
+    return default_naming.to_method_name(operation_id, method, path, ensure_unique)
+
+
+def to_param_var(raw_param_name: str) -> str:
+    """Convenience function using default naming strategy"""
+    return default_naming.to_param_var(raw_param_name)

--- a/src/devdox_ai_locust/utils/swagger_utils.py
+++ b/src/devdox_ai_locust/utils/swagger_utils.py
@@ -2,6 +2,8 @@ import httpx
 import os
 import re
 import uuid
+import aiofiles
+from pathlib import Path
 from typing import Optional
 from devdox_ai_locust.schemas.processing_result import SwaggerProcessingRequest
 import logging
@@ -11,18 +13,10 @@ logger = logging.getLogger(__name__)
 
 async def get_api_schema(source: SwaggerProcessingRequest) -> Optional[str]:
     """
-    Get API schema content from URL or file path based on source dictionary.
+    Get API schema content from URL or file path.
 
     Args:
-        source (dict): Dictionary containing swagger_source ("url" or "file") and swagger_url/swagger_path
-
-
-    Expected source structure:
-        {
-            "swagger_source": "url",  # or "file"
-            "swagger_url": "https://api.example.com/swagger.json",  # if source is "url"
-            "swagger_path": "/path/to/swagger.json"  # if source is "file"
-        }
+        source: SwaggerProcessingRequest containing either swagger_url or swagger_path
 
     Returns:
         Optional[str]: Schema content as string, or None if failed
@@ -33,20 +27,54 @@ async def get_api_schema(source: SwaggerProcessingRequest) -> Optional[str]:
         httpx.HTTPError: If URL request fails
         Exception: For other unexpected errors
     """
-
     try:
-        if not source.swagger_url:
-            raise ValueError("Missing or empty 'swagger_url'")
-        swagger_url = source.swagger_url.strip()
-        if not swagger_url:
-            raise ValueError("Missing 'swagger_url' for url source")
-        return await _fetch_from_url(swagger_url)
+        if source.is_url_source:
+            logger.info(f"Fetching schema from URL: {source.swagger_url}")
+            return await _fetch_from_url(source.swagger_url.strip())
+        elif source.is_file_source:
+            logger.info(f"Reading schema from file: {source.swagger_path}")
+            return await _read_from_file(source.swagger_path.strip())
+        else:
+            raise ValueError("No valid source provided (neither URL nor file path)")
 
     except Exception as e:
-        source_info = getattr(source, "swagger_url", "unknown")
-
-        logger.error(f"Failed to get API schema from  source '{source_info}': {str(e)}")
+        source_info = source.source_location if hasattr(source, 'source_location') else "unknown"
+        logger.error(f"Failed to get API schema from source '{source_info}': {str(e)}")
         raise
+
+
+async def _read_from_file(file_path: str) -> str:
+    """Read schema content from a local file."""
+    path = Path(file_path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Schema file not found: {file_path}")
+
+    if not path.is_file():
+        raise ValueError(f"Path is not a file: {file_path}")
+
+    # Check file extension for content type hints
+    suffix = path.suffix.lower()
+    if suffix not in {'.json', '.yaml', '.yml'}:
+        logger.warning(
+            f"File extension '{suffix}' is not a standard OpenAPI format. "
+            "Expected .json, .yaml, or .yml"
+        )
+
+    try:
+        async with aiofiles.open(path, mode='r', encoding='utf-8') as f:
+            content = await f.read()
+
+        if not content or not content.strip():
+            raise ValueError(f"Empty file: {file_path}")
+
+        logger.info(f"Successfully read schema file: {file_path} ({len(content)} bytes)")
+        return content.strip()
+
+    except UnicodeDecodeError as e:
+        raise ValueError(f"File encoding error (expected UTF-8): {file_path}") from e
+    except PermissionError as e:
+        raise PermissionError(f"Permission denied reading file: {file_path}") from e
 
 
 async def _fetch_from_url(url: str) -> str:


### PR DESCRIPTION
# Fix critical blocking defects in code generation pipeline

This commit addresses multiple blocking defects that prevented reliable
code generation from OpenAPI specifications:

**Swagger Source Handling (Issue 1.1)**
- Add swagger_path field to SwaggerProcessingRequest for file support
- Implement _read_from_file() in swagger_utils.py for local file handling
- Update CLI to auto-detect URL vs file path sources
- Add XOR validation: exactly one of swagger_url or swagger_path required

**Centralized Naming Strategy (Issue 1.2 / 3.1)**
- Create new utils/naming.py with DefaultNamingStrategy class
- Provide consistent transformations: to_workflow_module(), to_task_methods_class()
- Fix path parameter sanitization (user-id -> user_id)
- Ensure all generated names are valid Python identifiers
- Handle edge cases: leading digits, Python keywords, spaces, punctuation

**Task Methods Wipe Bug (Issue 1.3)**
- Remove erroneous `indented_task_methods = ""` line that wiped generated tasks

**Template Fixes**
- Fix workflow.j2: Replace {if}/{endif} with {% if %}/{% endif %} (Issue 1.4)
- Fix grouped_enpoints typo to grouped_endpoints
- Fix endpoint_template.py.j2: Use passed class names instead of Jinja filters
- Fix fallback_locust.py.j2: Use {% raw %} for Python f-strings with braces
- Fix locust.py.j2: Remove problematic APITaskMethods class

**AI Enhancement Deadlock (Issue 1.5)**
- Remove nested semaphore acquisition in _make_api_call()
- Semaphore now only acquired in _call_ai_service()

**Response Envelope for Type Safety (Issue 2.3)**
- Add ResponseEnvelope dataclass with status_code and payload
- Update make_request() to return ResponseEnvelope
- Add handle_401_retry() helper that properly checks status_code
- Add TYPE_CHECKING import for client type hints

**File Sanitization (Issue 2.6)**
- Fix _sanitize_filename() to handle spaces with regex
- Remove consecutive underscores and strip leading/trailing underscores

**Auth Endpoint Deduplication (Issue 2.5)**
- Auth endpoints now placed ONLY in Authentication group
- Add deduplication by (method, path) within groups

---

# Fix user class tasks and second sweep defects

- Fix user_classes.py.j2: Add tasks attribute to LightUser, RegularUser, PowerUser classes (was causing "No tasks defined" error)
- Fix _generate_user_classes: Pass tasks list to template
- Fix hybrid_loctus_generator.py: Correct workflow_item key check (dict key lookup instead of .get("file_name"))
- Fix hybrid_loctus_generator.py: Add missing space in parameter default
- Fix hybrid_loctus_generator.py: Remove stale line number from error msg
- Fix test_data.py.j2: Add missing property generation for non-$ref properties in _generate_object_data
- Fix base_workflow.py.j2: Fix identical if/else branches in on_stop
- Fix locust_generator.py: Remove duplicate typing import

---

# Fix workflows package import error

Add __init__.py file generation when creating the workflows/ directory.
This makes workflows a proper Python package so that imports like:
  from workflows.base_workflow import BaseAPIUser, BaseTaskMethods
work correctly when running Locust tests.

Fixes: ModuleNotFoundError: No module named 'workflows.base_workflow'

---

# Fix base_workflow.py deletion during AI enhancement

The process_workflow_enhancements method was skipping base_workflow.py
in the main loop because it was "handled above", but after processing
the enhanced file was never added to enhanced_directory_files.

This caused base_workflow.py to be completely missing from the output,
resulting in ModuleNotFoundError when running locust.

Fix:
- Add enhanced base_workflow.py to output after processing
- Preserve original if enhancement fails
- Preserve original if include_auth is False

---

# Add AI output validation and fallback to prevent code corruption

- Add critical class/function validation for test_data.py and utils.py
- Add _validate_critical_elements() to detect when AI deletes critical classes
- Add _safe_enhance_file() with automatic fallback to original template code
- Update process_test_data_enhancement() and process_validation_enhancement() to use validation and fallback mechanism
- Update prompt templates with explicit preservation requirements
- Add size validation to catch drastically reduced files

---

# Implement SafeCodeMerger for robust additive-only AI enhancement

Major architectural change to prevent AI code corruption:

1. SafeCodeMerger class:
   - ALWAYS keeps original code intact as the base
   - Only extracts NEW methods from AI output
   - Uses AST parsing to identify existing vs new methods
   - Regex fallback when AST parsing fails
   - Properly handles standalone method definitions

2. Simplified prompts (test_data.j2, validation.j2):
   - Now request ONLY new method definitions
   - Do NOT ask AI to rewrite entire files
   - Clear examples of expected output format
   - Reduced prompt complexity

3. Updated _safe_enhance_file:
   - Uses SafeCodeMerger for safe merging
   - Always preserves original code
   - Only adds validated new methods

This ensures AI enhancement can NEVER delete existing code.

---

# Add CodebaseAwareness for dependency-based AI sandboxing

This creates an intelligent sandbox that tells AI what it can/cannot modify
based on actual codebase dependencies:

1. CodebaseAwareness class:
   - Analyzes all generated files using AST
   - Extracts exports (classes, functions, constants) per file
   - Maps imports to understand cross-file dependencies
   - Identifies "protected" symbols (used by other files)
   - Generates constraints in human-readable format

2. ProtectedSymbol dataclass:
   - Tracks symbol name, type, where defined, who uses it
   - Provides clear reason why it's protected

3. Integration with enhancement pipeline:
   - EnhancementProcessor now receives CodebaseAwareness
   - Constraints are passed to AI prompts
   - AI sees exactly what it MUST preserve and why

4. Updated prompts (test_data.j2, validation.j2):
   - Include constraints section from CodebaseAwareness
   - AI now knows which symbols are imported by other files
   - Clear guidance on what can be added vs what must stay

Example constraint output:
🔒 PROTECTED SYMBOLS (DO NOT REMOVE - used by other files):
  CLASSES:
    - TestDataGenerator
      Reason: Imported by: locustfile.py, workflows/user_workflow.py

---

# Fix authentication method resolution bug in LLM prompts

The LLM was incorrectly generating code that called super().login_and_get_token()
and super().logout_session(), but these methods don't exist in parent classes
(SequentialTaskSet or BaseTaskMethods).

Changes:
- Clarify that login_and_get_token and logout_session must be defined in the workflow class itself, not inherited
- Emphasize calling via self (self.login_and_get_token()) not super()
- Add explicit "WRONG PATTERN" examples showing what NOT to do
- Update Authentication Phase and Logout Phase sections with correct guidance
- Fix misleading "use base_workflow auth methods" instructions

This fixes PyCharm/IDE warnings like:
"Unresolved attribute reference 'login_and_get_token' for class 'SequentialTaskSet'"

---

# Fix Locust catch_response pattern and prevent inventing endpoints

- Add critical warning that catch_response=True MUST use with-block
- Show correct vs wrong patterns for response.success()/failure()
- Add explicit warning not to invent authentication endpoints
- Clarify that login/logout should only use endpoints from OpenAPI spec
- If no auth endpoints exist, skip authentication and use config.api_key

---

# Support flexible authentication endpoint naming in prompts

- Remove assumption that auth endpoints must be named "login/logout"
- Support various auth patterns: /auth/token, /oauth/authorize, /session, etc.
- Key constraint: use endpoints FROM auth_endpoints, don't invent new ones
- If auth_endpoints is empty, use config.api_key instead