### PR TITLE
Dev 61 enhancement include a patch tracking system metadata manager wal inspired design progress display

### DIFF
--- a/src/devdox_ai_locust/cli.py
+++ b/src/devdox_ai_locust/cli.py
@@ -12,6 +12,7 @@ from .hybrid_loctus_generator import HybridLocustGenerator
 from .config import Settings
 from devdox_ai_locust.utils.swagger_utils import get_api_schema
 from devdox_ai_locust.utils.open_ai_parser import OpenAPIParser, Endpoint
+from devdox_ai_locust.utils.patch_tracker import PatchTracker
 from .schemas.processing_result import SwaggerProcessingRequest
 
 console = Console()
@@ -216,12 +217,36 @@ async def _generate_and_create_tests(
     host: Optional[str] = "0.0.0.0",
     auth: bool = False,
     db_type: str = "",
+    enable_patch_tracking: bool = True,
 ) -> List[Dict[Any, Any]]:
     """Generate tests using AI and create test files"""
     together_client = AsyncTogether(api_key=api_key)
 
+    # Initialize patch tracker for before/after LLM comparison
+    patch_tracker: Optional[PatchTracker] = None
+    if enable_patch_tracking:
+        patch_tracker = PatchTracker(output_dir)
+        patch_tracker.start_session(api_info)
+
     with console.status("[bold green]Generating Locust tests with AI..."):
         generator = HybridLocustGenerator(ai_client=together_client)
+
+        # First, generate base template files (pre-LLM)
+        base_files, base_directories, grouped_endpoints = (
+            generator.template_generator.generate_from_endpoints(
+                endpoints,
+                api_info,
+                include_auth=auth,
+                target_host=host,
+                db_type=db_type,
+            )
+        )
+
+        # Capture pre-LLM state
+        if patch_tracker:
+            patch_tracker.capture_pre_llm_state(base_files, base_directories)
+
+        # Now run the full hybrid generation (includes AI enhancement)
         test_files, test_directories = await generator.generate_from_endpoints(
             endpoints=endpoints,
             api_info=api_info,
@@ -230,6 +255,10 @@ async def _generate_and_create_tests(
             include_auth=auth,
             db_type=db_type,
         )
+
+        # Capture post-LLM state
+        if patch_tracker:
+            patch_tracker.capture_post_llm_state(test_files, test_directories)
 
     # Create test files
     with console.status("[bold green]Creating test files..."):
@@ -260,6 +289,17 @@ async def _generate_and_create_tests(
                 test_files, output_dir
             )
             created_files.extend(main_files)
+
+    # Finalize patch tracking
+    if patch_tracker:
+        patch_tracker.finalize_session(
+            api_info=api_info,
+            endpoints_count=len(endpoints),
+            ai_model=generator.ai_config.model if generator.ai_config else None,
+            enhancements_applied=[]  # Could be populated from enhancement result
+        )
+        patch_session_path = output_dir / ".devdox_ai_locust" / "patches" / patch_tracker._generate_session_id()
+        console.print(f"[blue]📋 Patch tracking saved to: .devdox_ai_locust/patches/[/blue]")
 
     return created_files
 

--- a/src/devdox_ai_locust/cli.py
+++ b/src/devdox_ai_locust/cli.py
@@ -452,7 +452,9 @@ async def _generate_and_create_tests(
     if patch_tracker:
         summary = patch_tracker.get_summary()
         patch_tracker.finalize()
-        console.print(f"[blue]📋 WAL patches saved to: .devdox_ai_locust/wal/ ({summary.get('total_patches', 0)} patches)[/blue]")
+        session_id = summary.get('session_id', '')
+        total = summary.get('total_patches', 0)
+        console.print(f"[blue]📋 Patches saved to: .devdox_ai_locust/{session_id}/.patches/ ({total} patches)[/blue]")
 
     # Finalize metadata
     metadata_manager.finalize_session()

--- a/src/devdox_ai_locust/cli.py
+++ b/src/devdox_ai_locust/cli.py
@@ -342,7 +342,7 @@ async def _generate_and_create_tests(
     patch_tracker: Optional[PatchTracker] = None
     if enable_patch_tracking:
         patch_tracker = PatchTracker.from_metadata_manager(metadata_manager)
-        patch_tracker.start_session(api_info)
+        patch_tracker.start_session()
 
     # Create progress display
     progress_display = ProgressDisplay()
@@ -376,9 +376,9 @@ async def _generate_and_create_tests(
             )
         )
 
-        # Capture pre-LLM state
+        # Capture template generation state
         if patch_tracker:
-            patch_tracker.capture_pre_llm_state(base_files, base_directories)
+            patch_tracker.capture_template_state(base_files, base_directories)
 
         # Now run the full hybrid generation (includes AI enhancement)
         test_files, test_directories = await generator.generate_from_endpoints(
@@ -390,9 +390,10 @@ async def _generate_and_create_tests(
             db_type=db_type,
         )
 
-        # Capture post-LLM state
+        # Capture AI-enhanced state
         if patch_tracker:
-            patch_tracker.capture_post_llm_state(test_files, test_directories)
+            ai_model = generator.ai_config.model if generator.ai_config else None
+            patch_tracker.capture_enhanced_state(test_files, test_directories, ai_model=ai_model)
 
         # Update progress for file writing
         await progress_callback(ProgressStatus(
@@ -449,13 +450,9 @@ async def _generate_and_create_tests(
 
     # Finalize patch tracking
     if patch_tracker:
-        patch_tracker.finalize_session(
-            api_info=api_info,
-            endpoints_count=len(endpoints),
-            ai_model=generator.ai_config.model if generator.ai_config else None,
-            enhancements_applied=[]  # Could be populated from enhancement result
-        )
-        console.print("[blue]📋 Patch tracking saved to: .devdox_ai_locust/ai_enhancement/patches/[/blue]")
+        summary = patch_tracker.get_summary()
+        patch_tracker.finalize()
+        console.print(f"[blue]📋 WAL patches saved to: .devdox_ai_locust/wal/ ({summary.get('total_patches', 0)} patches)[/blue]")
 
     # Finalize metadata
     metadata_manager.finalize_session()

--- a/src/devdox_ai_locust/cli.py
+++ b/src/devdox_ai_locust/cli.py
@@ -409,9 +409,6 @@ async def _generate_and_create_tests(
     console.print("[green]✓[/green] AI enhancement complete, writing files...")
     created_files = []
 
-    # Set output root directory name
-    metadata_manager.set_output_root(output_dir.name)
-
     # Create workflow files
     if test_directories:
         workflows_dir = output_dir / "workflows"
@@ -422,16 +419,12 @@ async def _generate_and_create_tests(
         init_file = workflows_dir / "__init__.py"
         init_file.write_text(init_content, encoding="utf-8")
         created_files.append({"filename": "workflows/__init__.py", "path": init_file})
-        metadata_manager.register_file(
-            "workflows/__init__.py", init_content, category="workflow"
-        )
+        metadata_manager.register_file("workflows/__init__.py", init_content)
 
         for file_workflow in test_directories:
-            # Register workflow files with metadata
+            # Register workflow files
             for filename, content in file_workflow.items():
-                metadata_manager.register_file(
-                    f"workflows/{filename}", content, category="workflow"
-                )
+                metadata_manager.register_file(f"workflows/{filename}", content)
             workflow_files = await generator._create_test_files_safely(
                 file_workflow, workflows_dir
             )
@@ -439,16 +432,9 @@ async def _generate_and_create_tests(
 
     # Create main test files
     if test_files:
-        # Register main files with metadata
+        # Register files in tree
         for filename, content in test_files.items():
-            # Determine category based on filename
-            if filename in ("config.py", ".env.example", "env.example"):
-                category = "config"
-            elif filename in ("requirements.txt", "readme.md", "README.md"):
-                category = "docs"
-            else:
-                category = "main"
-            metadata_manager.register_file(filename, content, category=category)
+            metadata_manager.register_file(filename, content)
 
         main_files = await generator._create_test_files_safely(
             test_files, output_dir

--- a/src/devdox_ai_locust/cli.py
+++ b/src/devdox_ai_locust/cli.py
@@ -13,6 +13,7 @@ from .config import Settings
 from devdox_ai_locust.utils.swagger_utils import get_api_schema
 from devdox_ai_locust.utils.open_ai_parser import OpenAPIParser, Endpoint
 from devdox_ai_locust.utils.patch_tracker import PatchTracker
+from devdox_ai_locust.utils.metadata_manager import MetadataManager
 from .schemas.processing_result import SwaggerProcessingRequest
 
 console = Console()
@@ -213,6 +214,8 @@ async def _generate_and_create_tests(
     endpoints: List[Endpoint],
     api_info: Dict[str, Any],
     output_dir: Path,
+    swagger_source: str = "",
+    source_type: str = "",
     custom_requirement: Optional[str] = "",
     host: Optional[str] = "0.0.0.0",
     auth: bool = False,
@@ -222,14 +225,34 @@ async def _generate_and_create_tests(
     """Generate tests using AI and create test files"""
     together_client = AsyncTogether(api_key=api_key)
 
-    # Initialize patch tracker for before/after LLM comparison
+    # Initialize central metadata manager
+    metadata_manager = MetadataManager(output_dir)
+    session_id = metadata_manager.initialize_session(
+        api_info=api_info,
+        swagger_source=swagger_source,
+        source_type=source_type
+    )
+    metadata_manager.update_api_endpoints_count(len(endpoints))
+    metadata_manager.update_generation_config(
+        host=host,
+        auth_enabled=auth,
+        db_type=db_type,
+        custom_requirement=custom_requirement
+    )
+
+    # Initialize patch tracker integrated with metadata manager
     patch_tracker: Optional[PatchTracker] = None
     if enable_patch_tracking:
-        patch_tracker = PatchTracker(output_dir)
+        patch_tracker = PatchTracker.from_metadata_manager(metadata_manager)
         patch_tracker.start_session(api_info)
 
     with console.status("[bold green]Generating Locust tests with AI..."):
         generator = HybridLocustGenerator(ai_client=together_client)
+
+        # Update metadata with AI model
+        metadata_manager.update_generation_config(
+            ai_model=generator.ai_config.model if generator.ai_config else None
+        )
 
         # First, generate base template files (pre-LLM)
         base_files, base_directories, grouped_endpoints = (
@@ -263,6 +286,8 @@ async def _generate_and_create_tests(
     # Create test files
     with console.status("[bold green]Creating test files..."):
         created_files = []
+        main_file_names = []
+        workflow_file_names = []
 
         # Create workflow files
         if test_directories:
@@ -276,12 +301,15 @@ async def _generate_and_create_tests(
                 encoding="utf-8"
             )
             created_files.append({"filename": "workflows/__init__.py", "path": init_file})
+            workflow_file_names.append("workflows/__init__.py")
 
             for file_workflow in test_directories:
                 workflow_files = await generator._create_test_files_safely(
                     file_workflow, workflows_dir
                 )
                 created_files.extend(workflow_files)
+                for wf in workflow_files:
+                    workflow_file_names.append(f"workflows/{wf.get('filename', '')}")
 
         # Create main test files
         if test_files:
@@ -289,6 +317,14 @@ async def _generate_and_create_tests(
                 test_files, output_dir
             )
             created_files.extend(main_files)
+            for mf in main_files:
+                main_file_names.append(mf.get('filename', ''))
+
+    # Register files with metadata manager
+    metadata_manager.register_files(
+        main_files=main_file_names,
+        workflow_files=workflow_file_names
+    )
 
     # Finalize patch tracking
     if patch_tracker:
@@ -298,8 +334,11 @@ async def _generate_and_create_tests(
             ai_model=generator.ai_config.model if generator.ai_config else None,
             enhancements_applied=[]  # Could be populated from enhancement result
         )
-        patch_session_path = output_dir / ".devdox_ai_locust" / "patches" / patch_tracker._generate_session_id()
-        console.print(f"[blue]📋 Patch tracking saved to: .devdox_ai_locust/patches/[/blue]")
+        console.print("[blue]📋 Patch tracking saved to: .devdox_ai_locust/patches/[/blue]")
+
+    # Finalize metadata
+    metadata_manager.finalize_session()
+    console.print("[blue]📄 Metadata saved to: .devdox_ai_locust/metadata.json[/blue]")
 
     return created_files
 
@@ -443,10 +482,12 @@ async def _async_generate(
             endpoints,
             api_info,
             output_dir,
-            custom_requirement,
-            host,
-            auth,
-            db_type,
+            swagger_source=swagger_url,
+            source_type="url",
+            custom_requirement=custom_requirement,
+            host=host,
+            auth=auth,
+            db_type=db_type,
         )
 
         # Show results

--- a/src/devdox_ai_locust/cli.py
+++ b/src/devdox_ai_locust/cli.py
@@ -6,9 +6,13 @@ from datetime import datetime, timezone
 from typing import Optional, Tuple, Union, List, Dict, Any
 from rich.console import Console
 from rich.table import Table
+from rich.live import Live
+from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskID
 from together import AsyncTogether
 
 from .hybrid_loctus_generator import HybridLocustGenerator
+from .schemas.progress import ProgressStatus, ProgressPhase
 from .config import Settings
 from devdox_ai_locust.utils.swagger_utils import get_api_schema
 from devdox_ai_locust.utils.open_ai_parser import OpenAPIParser, Endpoint
@@ -209,6 +213,100 @@ async def _process_api_schema(
             sys.exit(1)
 
 
+class ProgressDisplay:
+    """Manages live progress display for generation"""
+
+    # Phase descriptions for display
+    PHASE_ICONS = {
+        ProgressPhase.INITIALIZING: "🔧",
+        ProgressPhase.PARSING_SCHEMA: "📖",
+        ProgressPhase.GENERATING_TEMPLATES: "📝",
+        ProgressPhase.ANALYZING_CODEBASE: "🔍",
+        ProgressPhase.ENHANCING_LOCUSTFILE: "🤖",
+        ProgressPhase.ENHANCING_TEST_DATA: "🤖",
+        ProgressPhase.ENHANCING_VALIDATION: "🤖",
+        ProgressPhase.ENHANCING_DOMAIN_FLOWS: "🤖",
+        ProgressPhase.ENHANCING_WORKFLOWS: "🤖",
+        ProgressPhase.MERGING_CODE: "🔀",
+        ProgressPhase.VALIDATING_OUTPUT: "✅",
+        ProgressPhase.WRITING_FILES: "💾",
+        ProgressPhase.FINALIZING: "📦",
+        ProgressPhase.COMPLETE: "🎉",
+        ProgressPhase.FAILED: "❌",
+    }
+
+    def __init__(self):
+        self.progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(bar_width=30),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TextColumn("[dim]{task.fields[detail]}"),
+            console=console,
+            transient=False,
+        )
+        self.main_task: Optional[TaskID] = None
+        self.current_status = ""
+        self.completed_phases: List[str] = []
+
+    def start(self) -> None:
+        """Start the progress display"""
+        self.main_task = self.progress.add_task(
+            "Generating tests...",
+            total=100,
+            detail="Initializing..."
+        )
+        self.progress.start()
+
+    def stop(self) -> None:
+        """Stop the progress display"""
+        self.progress.stop()
+
+    async def update(self, status: ProgressStatus) -> None:
+        """Update the progress display with new status"""
+        if self.main_task is None:
+            return
+
+        icon = self.PHASE_ICONS.get(status.phase, "⏳")
+        message = f"{icon} {status.message}"
+
+        # Calculate overall progress based on phase
+        phase_progress = {
+            ProgressPhase.INITIALIZING: 5,
+            ProgressPhase.GENERATING_TEMPLATES: 15,
+            ProgressPhase.ANALYZING_CODEBASE: 20,
+            ProgressPhase.ENHANCING_LOCUSTFILE: 35,
+            ProgressPhase.ENHANCING_TEST_DATA: 50,
+            ProgressPhase.ENHANCING_VALIDATION: 60,
+            ProgressPhase.ENHANCING_DOMAIN_FLOWS: 70,
+            ProgressPhase.ENHANCING_WORKFLOWS: 85,
+            ProgressPhase.VALIDATING_OUTPUT: 90,
+            ProgressPhase.WRITING_FILES: 95,
+            ProgressPhase.COMPLETE: 100,
+            ProgressPhase.FAILED: 100,
+        }
+
+        progress_value = phase_progress.get(status.phase, 0)
+        detail = status.detail or ""
+
+        # Add AI indicator
+        if status.is_ai_call:
+            detail = f"[yellow]AI[/yellow] {detail}"
+
+        self.progress.update(
+            self.main_task,
+            completed=progress_value,
+            description=message,
+            detail=detail,
+        )
+
+        # Print completed phases
+        if status.phase not in [ProgressPhase.COMPLETE, ProgressPhase.FAILED]:
+            phase_str = f"{icon} {status.message}"
+            if phase_str not in self.completed_phases:
+                self.completed_phases.append(phase_str)
+
+
 async def _generate_and_create_tests(
     api_key: str,
     endpoints: List[Endpoint],
@@ -246,8 +344,21 @@ async def _generate_and_create_tests(
         patch_tracker = PatchTracker.from_metadata_manager(metadata_manager)
         patch_tracker.start_session(api_info)
 
-    with console.status("[bold green]Generating Locust tests with AI..."):
-        generator = HybridLocustGenerator(ai_client=together_client)
+    # Create progress display
+    progress_display = ProgressDisplay()
+
+    async def progress_callback(status: ProgressStatus) -> None:
+        """Callback to update progress display"""
+        await progress_display.update(status)
+
+    try:
+        progress_display.start()
+
+        # Create generator with progress callback
+        generator = HybridLocustGenerator(
+            ai_client=together_client,
+            progress_callback=progress_callback,
+        )
 
         # Update metadata with AI model
         metadata_manager.update_generation_config(
@@ -283,42 +394,52 @@ async def _generate_and_create_tests(
         if patch_tracker:
             patch_tracker.capture_post_llm_state(test_files, test_directories)
 
+        # Update progress for file writing
+        await progress_callback(ProgressStatus(
+            phase=ProgressPhase.WRITING_FILES,
+            message="Writing output files",
+            detail=f"Creating {len(test_files)} files...",
+        ))
+
+    finally:
+        progress_display.stop()
+
     # Create test files
-    with console.status("[bold green]Creating test files..."):
-        created_files = []
-        main_file_names = []
-        workflow_file_names = []
+    console.print("[green]✓[/green] AI enhancement complete, writing files...")
+    created_files = []
+    main_file_names = []
+    workflow_file_names = []
 
-        # Create workflow files
-        if test_directories:
-            workflows_dir = output_dir / "workflows"
-            workflows_dir.mkdir(exist_ok=True)
+    # Create workflow files
+    if test_directories:
+        workflows_dir = output_dir / "workflows"
+        workflows_dir.mkdir(exist_ok=True)
 
-            # Create __init__.py to make workflows a proper Python package
-            init_file = workflows_dir / "__init__.py"
-            init_file.write_text(
-                '"""Workflow modules for Locust load testing"""\n',
-                encoding="utf-8"
+        # Create __init__.py to make workflows a proper Python package
+        init_file = workflows_dir / "__init__.py"
+        init_file.write_text(
+            '"""Workflow modules for Locust load testing"""\n',
+            encoding="utf-8"
+        )
+        created_files.append({"filename": "workflows/__init__.py", "path": init_file})
+        workflow_file_names.append("workflows/__init__.py")
+
+        for file_workflow in test_directories:
+            workflow_files = await generator._create_test_files_safely(
+                file_workflow, workflows_dir
             )
-            created_files.append({"filename": "workflows/__init__.py", "path": init_file})
-            workflow_file_names.append("workflows/__init__.py")
+            created_files.extend(workflow_files)
+            for wf in workflow_files:
+                workflow_file_names.append(f"workflows/{wf.get('filename', '')}")
 
-            for file_workflow in test_directories:
-                workflow_files = await generator._create_test_files_safely(
-                    file_workflow, workflows_dir
-                )
-                created_files.extend(workflow_files)
-                for wf in workflow_files:
-                    workflow_file_names.append(f"workflows/{wf.get('filename', '')}")
-
-        # Create main test files
-        if test_files:
-            main_files = await generator._create_test_files_safely(
-                test_files, output_dir
-            )
-            created_files.extend(main_files)
-            for mf in main_files:
-                main_file_names.append(mf.get('filename', ''))
+    # Create main test files
+    if test_files:
+        main_files = await generator._create_test_files_safely(
+            test_files, output_dir
+        )
+        created_files.extend(main_files)
+        for mf in main_files:
+            main_file_names.append(mf.get('filename', ''))
 
     # Register files with metadata manager
     metadata_manager.register_files(
@@ -334,7 +455,7 @@ async def _generate_and_create_tests(
             ai_model=generator.ai_config.model if generator.ai_config else None,
             enhancements_applied=[]  # Could be populated from enhancement result
         )
-        console.print("[blue]📋 Patch tracking saved to: .devdox_ai_locust/patches/[/blue]")
+        console.print("[blue]📋 Patch tracking saved to: .devdox_ai_locust/ai_enhancement/patches/[/blue]")
 
     # Finalize metadata
     metadata_manager.finalize_session()

--- a/src/devdox_ai_locust/cli.py
+++ b/src/devdox_ai_locust/cli.py
@@ -408,8 +408,9 @@ async def _generate_and_create_tests(
     # Create test files
     console.print("[green]✓[/green] AI enhancement complete, writing files...")
     created_files = []
-    main_file_names = []
-    workflow_file_names = []
+
+    # Set output root directory name
+    metadata_manager.set_output_root(output_dir.name)
 
     # Create workflow files
     if test_directories:
@@ -417,36 +418,42 @@ async def _generate_and_create_tests(
         workflows_dir.mkdir(exist_ok=True)
 
         # Create __init__.py to make workflows a proper Python package
+        init_content = '"""Workflow modules for Locust load testing"""\n'
         init_file = workflows_dir / "__init__.py"
-        init_file.write_text(
-            '"""Workflow modules for Locust load testing"""\n',
-            encoding="utf-8"
-        )
+        init_file.write_text(init_content, encoding="utf-8")
         created_files.append({"filename": "workflows/__init__.py", "path": init_file})
-        workflow_file_names.append("workflows/__init__.py")
+        metadata_manager.register_file(
+            "workflows/__init__.py", init_content, category="workflow"
+        )
 
         for file_workflow in test_directories:
+            # Register workflow files with metadata
+            for filename, content in file_workflow.items():
+                metadata_manager.register_file(
+                    f"workflows/{filename}", content, category="workflow"
+                )
             workflow_files = await generator._create_test_files_safely(
                 file_workflow, workflows_dir
             )
             created_files.extend(workflow_files)
-            for wf in workflow_files:
-                workflow_file_names.append(f"workflows/{wf.get('filename', '')}")
 
     # Create main test files
     if test_files:
+        # Register main files with metadata
+        for filename, content in test_files.items():
+            # Determine category based on filename
+            if filename in ("config.py", ".env.example", "env.example"):
+                category = "config"
+            elif filename in ("requirements.txt", "readme.md", "README.md"):
+                category = "docs"
+            else:
+                category = "main"
+            metadata_manager.register_file(filename, content, category=category)
+
         main_files = await generator._create_test_files_safely(
             test_files, output_dir
         )
         created_files.extend(main_files)
-        for mf in main_files:
-            main_file_names.append(mf.get('filename', ''))
-
-    # Register files with metadata manager
-    metadata_manager.register_files(
-        main_files=main_file_names,
-        workflow_files=workflow_file_names
-    )
 
     # Finalize patch tracking
     if patch_tracker:

--- a/src/devdox_ai_locust/hybrid_loctus_generator.py
+++ b/src/devdox_ai_locust/hybrid_loctus_generator.py
@@ -1356,7 +1356,84 @@ class HybridLocustGenerator:
                 end_idx = i + 1
                 break
 
-        return "\n".join(lines[start_idx:end_idx])
+        cleaned_content = "\n".join(lines[start_idx:end_idx])
+
+        # Remove duplicate/appended class definitions that don't belong
+        # This handles cases where AI appends TestDataGenerator or other unrelated classes
+        cleaned_content = self._remove_duplicate_class_definitions(cleaned_content)
+
+        return cleaned_content
+
+    def _remove_duplicate_class_definitions(self, content: str) -> str:
+        """
+        Remove duplicate or unrelated class definitions that AI might append.
+
+        This fixes issues where the AI appends classes like TestDataGenerator
+        to workflow files where they don't belong.
+        """
+        # Classes that should NOT appear in workflow files (they're in separate files)
+        excluded_classes = {
+            "TestDataGenerator",
+            "LoadTestConfig",
+            "ResponseValidator",
+            "RequestLogger",
+            "PerformanceMonitor",
+            "DataManager",
+        }
+
+        lines = content.split("\n")
+        result_lines = []
+        skip_until_next_class = False
+        current_indent = 0
+
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.strip()
+
+            # Check if this is a class definition we should exclude
+            if stripped.startswith("class "):
+                class_match = re.match(r"class\s+(\w+)", stripped)
+                if class_match:
+                    class_name = class_match.group(1)
+                    if class_name in excluded_classes:
+                        # Skip this entire class definition
+                        skip_until_next_class = True
+                        current_indent = len(line) - len(line.lstrip())
+                        i += 1
+                        continue
+                    else:
+                        skip_until_next_class = False
+
+            # If we're skipping a class, check if we've exited it
+            if skip_until_next_class:
+                if stripped and not stripped.startswith("#"):
+                    line_indent = len(line) - len(line.lstrip())
+                    # Check if we've returned to the same or lower indent level
+                    # (which means we've exited the class)
+                    if line_indent <= current_indent and not line.startswith(" " * (current_indent + 1)):
+                        # Check if this is a new top-level definition
+                        if stripped.startswith(("class ", "def ", "if __name__", "# Global")):
+                            # Check if it's another excluded class
+                            if stripped.startswith("class "):
+                                class_match = re.match(r"class\s+(\w+)", stripped)
+                                if class_match and class_match.group(1) in excluded_classes:
+                                    i += 1
+                                    continue
+                            skip_until_next_class = False
+                        else:
+                            i += 1
+                            continue
+                else:
+                    i += 1
+                    continue
+
+            if not skip_until_next_class:
+                result_lines.append(line)
+
+            i += 1
+
+        return "\n".join(result_lines)
 
     def _analyze_api_domain(
         self, endpoints: List[Endpoint], api_info: Dict[str, Any]

--- a/src/devdox_ai_locust/hybrid_loctus_generator.py
+++ b/src/devdox_ai_locust/hybrid_loctus_generator.py
@@ -9,15 +9,18 @@ import ast
 import re
 import asyncio
 import logging
-from typing import Dict, List, Any, Optional, Tuple, Set
+from typing import Dict, List, Any, Optional, Tuple, Set, Callable, Awaitable
 from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
-from dataclasses import dataclass
+from pydantic import BaseModel, Field
 import uuid
 import shutil
 
 
 from devdox_ai_locust.utils.open_ai_parser import Endpoint
+from devdox_ai_locust.schemas.progress import (
+    ProgressCallback, ProgressStatus, ProgressPhase
+)
 from devdox_ai_locust.utils.file_creation import FileCreationConfig, SafeFileCreator
 from devdox_ai_locust.locust_generator import LocustTestGenerator, TestDataConfig
 from together import AsyncTogether
@@ -252,14 +255,16 @@ class SafeCodeMerger:
         return original_code + "\n\n# AI-enhanced additions\n" + new_methods
 
 
-@dataclass
-class ProtectedSymbol:
+class ProtectedSymbol(BaseModel):
     """A symbol that is protected because other files depend on it."""
     name: str
     symbol_type: str  # 'class', 'function', 'method', 'constant'
     defined_in: str  # file where it's defined
     used_by: List[str]  # files that import/use it
     reason: str  # why it's protected
+
+    class Config:
+        frozen = True
 
 
 class CodebaseAwareness:
@@ -482,19 +487,15 @@ class CodebaseAwareness:
         return "\n".join(context)
 
 
-@dataclass
-class ErrorClassification:
+class ErrorClassification(BaseModel):
     """Classification of an error for retry logic"""
-
     is_retryable: bool
     backoff_seconds: float
     error_type: str
 
 
-@dataclass
-class AIEnhancementConfig:
+class AIEnhancementConfig(BaseModel):
     """Configuration for AI enhancement"""
-
     model: str = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
     max_tokens: int = 8000
     temperature: float = 0.3
@@ -506,16 +507,14 @@ class AIEnhancementConfig:
     update_main_locust: bool = True
 
 
-@dataclass
-class EnhancementResult:
+class EnhancementResult(BaseModel):
     """Result of AI enhancement"""
-
     success: bool
-    enhanced_files: Dict[str, str]
-    enhanced_directory_files: List[Dict[str, Any]]
-    enhancements_applied: List[str]
-    errors: List[str]
-    processing_time: float
+    enhanced_files: Dict[str, str] = Field(default_factory=dict)
+    enhanced_directory_files: List[Dict[str, Any]] = Field(default_factory=list)
+    enhancements_applied: List[str] = Field(default_factory=list)
+    errors: List[str] = Field(default_factory=list)
+    processing_time: float = 0.0
 
 
 class EnhancementProcessor:
@@ -774,12 +773,14 @@ class HybridLocustGenerator:
         ai_config: Optional[AIEnhancementConfig] = None,
         test_config: Optional[TestDataConfig] = None,
         prompt_dir: str = "prompt",
+        progress_callback: Optional[ProgressCallback] = None,
     ):
         self.ai_client = ai_client
         self.ai_config = ai_config or AIEnhancementConfig()
         self.template_generator = LocustTestGenerator(test_config)
         self.prompt_dir = self._find_project_root() / prompt_dir
         self._api_semaphore = asyncio.Semaphore(5)
+        self._progress_callback = progress_callback
         self._setup_jinja_env()
         self.MAX_RETRIES = 3
         self.RATE_LIMIT_BACKOFF = 10
@@ -793,6 +794,27 @@ class HybridLocustGenerator:
             "invalid token",
         ]
         self.RATE_LIMIT_INDICATORS = ["429", "rate limit"]
+
+    async def _report_progress(
+        self,
+        phase: ProgressPhase,
+        message: str,
+        detail: Optional[str] = None,
+        current: int = 0,
+        total: int = 0,
+        is_ai_call: bool = False,
+    ) -> None:
+        """Report progress to callback if available"""
+        if self._progress_callback:
+            status = ProgressStatus(
+                phase=phase,
+                message=message,
+                detail=detail,
+                current=current,
+                total=total,
+                is_ai_call=is_ai_call,
+            )
+            await self._progress_callback(status)
 
     def _find_project_root(self) -> Path:
         """Find the project root by looking for setup.py, pyproject.toml, or .git"""
@@ -869,6 +891,11 @@ class HybridLocustGenerator:
 
         try:
             # Step 1: Generate reliable base structure
+            await self._report_progress(
+                ProgressPhase.GENERATING_TEMPLATES,
+                "Generating base test structure",
+                detail=f"Processing {len(endpoints)} endpoints",
+            )
             logger.info("🔧 Generating base test structure with templates...")
             base_files, directory_files, grouped_enpoints = (
                 self.template_generator.generate_from_endpoints(
@@ -881,6 +908,7 @@ class HybridLocustGenerator:
             )
 
             base_files = self.template_generator.fix_indent(base_files)
+
             # Step 2: Enhance with AI if available
             if self.ai_client and self._should_enhance(endpoints, api_info):
                 logger.info("🤖 Enhancing tests with AI...")
@@ -895,6 +923,11 @@ class HybridLocustGenerator:
                     db_type,
                 )
                 if enhancement_result.success:
+                    await self._report_progress(
+                        ProgressPhase.COMPLETE,
+                        "AI enhancements applied successfully",
+                        detail=f"Applied: {', '.join(enhancement_result.enhancements_applied)}",
+                    )
                     logger.info(
                         f"✅ AI enhancements applied: {', '.join(enhancement_result.enhancements_applied)}"
                     )
@@ -903,10 +936,19 @@ class HybridLocustGenerator:
                         enhancement_result.enhanced_directory_files,
                     )
                 else:
+                    await self._report_progress(
+                        ProgressPhase.COMPLETE,
+                        "Using template base (AI enhancement failed)",
+                        detail=f"Errors: {', '.join(enhancement_result.errors)}",
+                    )
                     logger.warning(
                         f"⚠️ AI enhancement failed, using template base: {', '.join(enhancement_result.errors)}"
                     )
             else:
+                await self._report_progress(
+                    ProgressPhase.COMPLETE,
+                    "Template-based generation complete",
+                )
                 logger.info("📋 Using template-based generation only")
 
             processing_time = asyncio.get_event_loop().time() - start_time
@@ -915,6 +957,11 @@ class HybridLocustGenerator:
             return base_files, directory_files
 
         except Exception as e:
+            await self._report_progress(
+                ProgressPhase.FAILED,
+                "Generation failed",
+                detail=str(e),
+            )
             logger.error(f"Hybrid generation failed: {e}")
 
             return {}, []
@@ -1042,10 +1089,16 @@ class HybridLocustGenerator:
     ) -> EnhancementResult:
         """Process all enhancements using the enhancement processor"""
         # Analyze codebase to understand dependencies
+        await self._report_progress(
+            ProgressPhase.ANALYZING_CODEBASE,
+            "Analyzing codebase dependencies",
+            detail="Identifying protected symbols",
+        )
         awareness = CodebaseAwareness()
         awareness.analyze_codebase(base_files, directory_files)
 
         # Log the protected symbols for debugging
+        protected_count = sum(len(p) for p in awareness.protected.values())
         logger.info("📊 Codebase analysis complete:")
         for filename, protected in awareness.protected.items():
             if protected:
@@ -1057,32 +1110,49 @@ class HybridLocustGenerator:
         enhanced_directory_files = []
         enhancements_applied: List[str] = []
         errors = []
-        # Process each enhancement type
-        enhancement_tasks = [
-            processor.process_main_locust_enhancement(base_files, endpoints, api_info),
-            processor.process_domain_flows_enhancement(
-                endpoints, api_info, custom_requirement
-            ),
-            processor.process_test_data_enhancement(base_files, endpoints, db_type),
-            processor.process_validation_enhancement(base_files, endpoints),
+
+        # Process enhancements sequentially for better progress visibility
+        enhancement_steps = [
+            (ProgressPhase.ENHANCING_LOCUSTFILE, "Enhancing main locustfile",
+             lambda: processor.process_main_locust_enhancement(base_files, endpoints, api_info)),
+            (ProgressPhase.ENHANCING_DOMAIN_FLOWS, "Generating domain-specific flows",
+             lambda: processor.process_domain_flows_enhancement(endpoints, api_info, custom_requirement)),
+            (ProgressPhase.ENHANCING_TEST_DATA, "Enhancing test data generator",
+             lambda: processor.process_test_data_enhancement(base_files, endpoints, db_type)),
+            (ProgressPhase.ENHANCING_VALIDATION, "Enhancing validation utilities",
+             lambda: processor.process_validation_enhancement(base_files, endpoints)),
         ]
 
-        # Execute file-based enhancements concurrently
-        file_enhancement_results = await asyncio.gather(
-            *enhancement_tasks, return_exceptions=True
+        total_steps = len(enhancement_steps) + 1  # +1 for workflows
+        current_step = 0
+
+        for phase, message, task_fn in enhancement_steps:
+            current_step += 1
+            await self._report_progress(
+                phase, message,
+                detail="Calling AI model...",
+                current=current_step, total=total_steps,
+                is_ai_call=True,
+            )
+            try:
+                files, enhancements = await task_fn()
+                enhanced_files.update(files)
+                enhancements_applied.extend(enhancements)
+            except Exception as e:
+                errors.append(f"{message}: {str(e)}")
+                logger.warning(f"Enhancement step failed: {message} - {e}")
+
+        # Process workflow enhancements (the most time-consuming)
+        current_step += 1
+        await self._report_progress(
+            ProgressPhase.ENHANCING_WORKFLOWS,
+            "Enhancing workflow files",
+            detail=f"Processing {len(directory_files)} workflows...",
+            current=current_step, total=total_steps,
+            is_ai_call=True,
         )
 
-        # Process results from file-based enhancements
-        for result in file_enhancement_results:
-            if isinstance(result, BaseException):
-                errors.append(str(result))
-                continue
-
-            files, enhancements = result
-            enhanced_files.update(files)
-            enhancements_applied.extend(enhancements)
-
-        # Process workflow enhancements separately (more complex logic)
+        # Process workflow enhancements
         try:
             (
                 workflow_files,
@@ -1094,6 +1164,13 @@ class HybridLocustGenerator:
             enhancements_applied.extend(workflow_enhancements)
         except Exception as e:
             errors.append(f"Workflow enhancement error: {str(e)}")
+
+        # Report merging and validation
+        await self._report_progress(
+            ProgressPhase.VALIDATING_OUTPUT,
+            "Validating generated code",
+            detail=f"Applied {len(enhancements_applied)} enhancements",
+        )
 
         return EnhancementResult(
             success=len(errors) == 0,

--- a/src/devdox_ai_locust/schemas/progress.py
+++ b/src/devdox_ai_locust/schemas/progress.py
@@ -1,0 +1,93 @@
+"""
+Progress Tracking Models
+
+Provides progress callbacks and status tracking for generation operations.
+Uses Pydantic for validation and serialization.
+"""
+
+from enum import Enum
+from typing import Optional, Callable, Awaitable
+from pydantic import BaseModel, Field
+
+
+class ProgressPhase(str, Enum):
+    """Phases of the generation process"""
+    INITIALIZING = "initializing"
+    PARSING_SCHEMA = "parsing_schema"
+    GENERATING_TEMPLATES = "generating_templates"
+    ANALYZING_CODEBASE = "analyzing_codebase"
+    ENHANCING_LOCUSTFILE = "enhancing_locustfile"
+    ENHANCING_TEST_DATA = "enhancing_test_data"
+    ENHANCING_VALIDATION = "enhancing_validation"
+    ENHANCING_DOMAIN_FLOWS = "enhancing_domain_flows"
+    ENHANCING_WORKFLOWS = "enhancing_workflows"
+    MERGING_CODE = "merging_code"
+    VALIDATING_OUTPUT = "validating_output"
+    WRITING_FILES = "writing_files"
+    FINALIZING = "finalizing"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+
+class ProgressStatus(BaseModel):
+    """Status update for a generation phase"""
+    phase: ProgressPhase
+    message: str
+    detail: Optional[str] = None
+    current: int = 0
+    total: int = 0
+    is_ai_call: bool = False  # True if this phase involves an AI API call
+
+    @property
+    def percentage(self) -> float:
+        """Get completion percentage"""
+        if self.total == 0:
+            return 0.0
+        return (self.current / self.total) * 100
+
+    def format_progress(self) -> str:
+        """Format progress for display"""
+        if self.total > 0:
+            return f"{self.message} ({self.current}/{self.total})"
+        return self.message
+
+
+# Type alias for progress callbacks
+ProgressCallback = Callable[[ProgressStatus], Awaitable[None]]
+
+
+class GenerationProgress(BaseModel):
+    """Tracks overall generation progress"""
+    total_phases: int = 13  # Total number of phases
+    completed_phases: int = 0
+    current_phase: ProgressPhase = ProgressPhase.INITIALIZING
+    phase_messages: dict[str, str] = Field(default_factory=dict)
+    errors: list[str] = Field(default_factory=list)
+
+    # Human-readable phase descriptions
+    PHASE_DESCRIPTIONS: dict[ProgressPhase, str] = {
+        ProgressPhase.INITIALIZING: "Initializing generator",
+        ProgressPhase.PARSING_SCHEMA: "Parsing API schema",
+        ProgressPhase.GENERATING_TEMPLATES: "Generating base templates",
+        ProgressPhase.ANALYZING_CODEBASE: "Analyzing codebase dependencies",
+        ProgressPhase.ENHANCING_LOCUSTFILE: "Enhancing main locustfile",
+        ProgressPhase.ENHANCING_TEST_DATA: "Enhancing test data generator",
+        ProgressPhase.ENHANCING_VALIDATION: "Enhancing validation utilities",
+        ProgressPhase.ENHANCING_DOMAIN_FLOWS: "Generating domain-specific flows",
+        ProgressPhase.ENHANCING_WORKFLOWS: "Enhancing workflow files",
+        ProgressPhase.MERGING_CODE: "Safely merging AI enhancements",
+        ProgressPhase.VALIDATING_OUTPUT: "Validating generated code",
+        ProgressPhase.WRITING_FILES: "Writing output files",
+        ProgressPhase.FINALIZING: "Finalizing generation",
+        ProgressPhase.COMPLETE: "Generation complete",
+        ProgressPhase.FAILED: "Generation failed",
+    }
+
+    def get_phase_description(self, phase: ProgressPhase) -> str:
+        """Get human-readable description for a phase"""
+        return self.PHASE_DESCRIPTIONS.get(phase, str(phase.value))
+
+    @property
+    def overall_percentage(self) -> float:
+        """Get overall completion percentage"""
+        return (self.completed_phases / self.total_phases) * 100

--- a/src/devdox_ai_locust/utils/metadata_manager.py
+++ b/src/devdox_ai_locust/utils/metadata_manager.py
@@ -151,44 +151,22 @@ class GenerationConfig(BaseModel):
     custom_requirement: str = ""
 
 
-class FileEntry(BaseModel):
-    """Metadata for a single generated file"""
-    category: str = "main"  # main, workflow, config, data, docs
-    size_bytes: int = 0
+class FileNode(BaseModel):
+    """Metadata for a generated file in the test suite tree"""
+    size: int = 0
     lines: int = 0
-    description: str = ""
-
-
-class OutputSummary(BaseModel):
-    """Summary statistics for output"""
-    total_files: int = 0
-    total_bytes: int = 0
-    by_category: Dict[str, int] = Field(default_factory=dict)
-
-
-class OutputInfo(BaseModel):
-    """
-    Information about generated output with file tree structure.
-
-    Structure:
-        {
-            "root": "locust_tests_iter_7",
-            "files": {
-                "locustfile.py": {"category": "main", "size_bytes": 1234, ...},
-                "workflows/base_workflow.py": {"category": "workflow", ...}
-            },
-            "summary": {"total_files": 14, "total_bytes": 15000, ...}
-        }
-    """
-    root: str = ""
-    files: Dict[str, FileEntry] = Field(default_factory=dict)
-    summary: OutputSummary = Field(default_factory=OutputSummary)
 
 
 class CentralMetadata(BaseModel):
     """
     Central metadata structure for DevDox AI Locust.
     Stored in .devdox_ai_locust/metadata.json
+
+    The 'files' field is a simple tree tracking generated test suite files:
+        {
+            "locustfile.py": {"size": 1234, "lines": 50},
+            "workflows/base_workflow.py": {"size": 800, "lines": 45}
+        }
     """
     version: str = METADATA_VERSION
     session_id: str = ""
@@ -196,7 +174,7 @@ class CentralMetadata(BaseModel):
     updated_at: str = ""
     api: APIMetadata = Field(default_factory=APIMetadata)
     config: GenerationConfig = Field(default_factory=GenerationConfig)
-    output: OutputInfo = Field(default_factory=OutputInfo)
+    files: Dict[str, FileNode] = Field(default_factory=dict)
 
 
 class MetadataManager:
@@ -326,9 +304,6 @@ class MetadataManager:
         self.metadata.updated_at = now
         self.session_info.updated_at = now
 
-        # Calculate output summary
-        self._calculate_output_summary()
-
         # Save everything
         self._save_metadata()
         self._save_session()
@@ -436,62 +411,17 @@ class MetadataManager:
         if custom_requirement is not None:
             self.metadata.config.custom_requirement = custom_requirement
 
-    def register_file(
-        self,
-        path: str,
-        content: str,
-        category: str = "main",
-        description: str = "",
-    ) -> None:
+    def register_file(self, path: str, content: str) -> None:
         """
-        Register a single generated file with metadata.
+        Register a generated file in the tree.
 
         Args:
-            path: Relative path from output root (e.g., "workflows/base.py")
-            content: File content (used to calculate size and lines)
-            category: File category (main, workflow, config, data, docs)
-            description: Optional description of the file
+            path: Relative path (e.g., "workflows/base.py")
+            content: File content
         """
-        entry = FileEntry(
-            category=category,
-            size_bytes=len(content.encode("utf-8")),
+        self.metadata.files[path] = FileNode(
+            size=len(content.encode("utf-8")),
             lines=content.count("\n") + (1 if content and not content.endswith("\n") else 0),
-            description=description,
-        )
-        self.metadata.output.files[path] = entry
-
-    def register_files(
-        self,
-        files: Dict[str, str],
-        category: str = "main",
-    ) -> None:
-        """
-        Register multiple files at once.
-
-        Args:
-            files: Dict of {path: content}
-            category: Category for all files
-        """
-        for path, content in files.items():
-            self.register_file(path, content, category=category)
-
-    def set_output_root(self, root: str) -> None:
-        """Set the output root directory name"""
-        self.metadata.output.root = root
-
-    def _calculate_output_summary(self) -> None:
-        """Calculate output summary statistics"""
-        files = self.metadata.output.files
-        total_bytes = sum(f.size_bytes for f in files.values())
-        by_category: Dict[str, int] = {}
-
-        for entry in files.values():
-            by_category[entry.category] = by_category.get(entry.category, 0) + 1
-
-        self.metadata.output.summary = OutputSummary(
-            total_files=len(files),
-            total_bytes=total_bytes,
-            by_category=by_category,
         )
 
     # =========================================================================

--- a/src/devdox_ai_locust/utils/metadata_manager.py
+++ b/src/devdox_ai_locust/utils/metadata_manager.py
@@ -40,7 +40,7 @@ import logging
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List, Protocol, Set
-from dataclasses import dataclass, asdict, field
+from pydantic import BaseModel, Field
 from enum import Enum
 
 logger = logging.getLogger(__name__)
@@ -61,8 +61,7 @@ class SubDirectory(str, Enum):
     LOGS = "logs"
 
 
-@dataclass
-class APIMetadata:
+class APIMetadata(BaseModel):
     """Metadata about the API being tested"""
     title: str = "Unknown"
     version: str = "Unknown"
@@ -73,8 +72,7 @@ class APIMetadata:
     source_type: str = ""  # "url" or "file"
 
 
-@dataclass
-class GenerationMetadata:
+class GenerationMetadata(BaseModel):
     """Metadata about the generation session"""
     session_id: str = ""
     created_at: str = ""
@@ -84,21 +82,19 @@ class GenerationMetadata:
     custom_requirement: str = ""
     processing_time_seconds: float = 0.0
     ai_model: str = ""
-    enhancements_applied: List[str] = field(default_factory=list)
-    errors: List[str] = field(default_factory=list)
+    enhancements_applied: List[str] = Field(default_factory=list)
+    errors: List[str] = Field(default_factory=list)
 
 
-@dataclass
-class OutputMetadata:
+class OutputMetadata(BaseModel):
     """Metadata about generated output files"""
     directory: str = ""
-    main_files: List[str] = field(default_factory=list)
-    workflow_files: List[str] = field(default_factory=list)
+    main_files: List[str] = Field(default_factory=list)
+    workflow_files: List[str] = Field(default_factory=list)
     total_files: int = 0
 
 
-@dataclass
-class PatchSessionInfo:
+class PatchSessionInfo(BaseModel):
     """Information about a patch session"""
     session_id: str
     created_at: str
@@ -109,32 +105,28 @@ class PatchSessionInfo:
     files_removed: int = 0
 
 
-@dataclass
-class AIEnhancementMetadata:
+class AIEnhancementMetadata(BaseModel):
     """Metadata for AI enhancement feature"""
     enabled: bool = True
     total_sessions: int = 0
     latest_session: str = ""
-    sessions: List[str] = field(default_factory=list)
+    sessions: List[str] = Field(default_factory=list)
 
 
-@dataclass
-class CodebaseAnalysisMetadata:
+class CodebaseAnalysisMetadata(BaseModel):
     """Metadata for codebase analysis feature"""
     enabled: bool = True
     latest_session: str = ""
     total_protected_symbols: int = 0
 
 
-@dataclass
-class FeaturesMetadata:
+class FeaturesMetadata(BaseModel):
     """Container for all extensible features"""
-    ai_enhancement: AIEnhancementMetadata = field(default_factory=AIEnhancementMetadata)
-    codebase_analysis: CodebaseAnalysisMetadata = field(default_factory=CodebaseAnalysisMetadata)
+    ai_enhancement: AIEnhancementMetadata = Field(default_factory=AIEnhancementMetadata)
+    codebase_analysis: CodebaseAnalysisMetadata = Field(default_factory=CodebaseAnalysisMetadata)
 
 
-@dataclass
-class CentralMetadata:
+class CentralMetadata(BaseModel):
     """
     Central metadata structure for DevDox AI Locust.
 
@@ -144,10 +136,10 @@ class CentralMetadata:
     version: str = METADATA_VERSION
     created_at: str = ""
     updated_at: str = ""
-    api: APIMetadata = field(default_factory=APIMetadata)
-    generation: GenerationMetadata = field(default_factory=GenerationMetadata)
-    output: OutputMetadata = field(default_factory=OutputMetadata)
-    features: FeaturesMetadata = field(default_factory=FeaturesMetadata)
+    api: APIMetadata = Field(default_factory=APIMetadata)
+    generation: GenerationMetadata = Field(default_factory=GenerationMetadata)
+    output: OutputMetadata = Field(default_factory=OutputMetadata)
+    features: FeaturesMetadata = Field(default_factory=FeaturesMetadata)
 
 
 class MetadataStorageProtocol(Protocol):
@@ -224,7 +216,7 @@ class FileSystemMetadataStorage:
 
     def _metadata_to_dict(self, metadata: CentralMetadata) -> Dict[str, Any]:
         """Convert CentralMetadata to dictionary"""
-        return asdict(metadata)
+        return metadata.model_dump()
 
     def _dict_to_metadata(self, data: Dict[str, Any]) -> CentralMetadata:
         """Convert dictionary to CentralMetadata"""
@@ -695,7 +687,7 @@ class MetadataManager:
 
     def to_dict(self) -> Dict[str, Any]:
         """Export metadata as dictionary"""
-        return asdict(self.metadata)
+        return self.metadata.model_dump()
 
     # =========================================================================
     # Directory Structure Info

--- a/src/devdox_ai_locust/utils/metadata_manager.py
+++ b/src/devdox_ai_locust/utils/metadata_manager.py
@@ -1,31 +1,30 @@
 """
 Central Metadata Manager for DevDox AI Locust
 
-PostgreSQL WAL-Inspired Structure (v3.0)
-========================================
-
-Simple, flat, extensible design inspired by PostgreSQL's Write-Ahead Log.
+Simplified Structure (v3.0)
+===========================
 
 Directory Structure:
     .devdox_ai_locust/
-    ├── metadata.json       # Central metadata (API info, config)
-    ├── manifest.json       # WAL manifest - maps patches to milestones
-    └── wal/                # Write-Ahead Log - sequential patches
-        ├── 000001_a1b2c3d4.patch
-        ├── 000002_e5f6g7h8.patch
-        └── 000003_i9j0k1l2.patch
+    ├── metadata.json                    # Central metadata (API info, config)
+    └── {session_id}/                    # e.g., 2025-12-29_10-39-24
+        ├── session.json                 # Session milestones and patches info
+        └── .patches/                    # Sequential patch files
+            ├── 000001_a1b2c3d4.patch
+            └── 000002_e5f6g7h8.patch
 
 Key Concepts:
-    - Each code change milestone gets a sequential patch file
-    - Patches are named: {sequence}_{short_uuid}.patch
-    - manifest.json tracks what each patch represents
+    - Each generation session gets a datetime-stamped directory
+    - session.json tracks milestones (what each patch represents)
+    - .patches/ contains sequential UUID-named patch files
     - Milestones can be: template_generation, llm_enhancement, validation, etc.
     - Extensible for future milestones (user_edit, refactor, etc.)
 
-Example manifest.json:
+Example session.json:
     {
         "version": "3.0",
         "session_id": "2025-12-29_10-39-24",
+        "created_at": "2025-12-29T10:39:24Z",
         "patches": [
             {
                 "id": "000001_a1b2c3d4",
@@ -60,8 +59,8 @@ logger = logging.getLogger(__name__)
 
 METADATA_VERSION = "3.0"
 METADATA_FILENAME = "metadata.json"
-MANIFEST_FILENAME = "manifest.json"
-WAL_DIR = "wal"
+SESSION_FILENAME = "session.json"
+PATCHES_DIR = ".patches"
 DEVDOX_DIR_NAME = ".devdox_ai_locust"
 
 
@@ -83,7 +82,7 @@ class PatchStats(BaseModel):
 
 
 class PatchEntry(BaseModel):
-    """Entry in the WAL manifest"""
+    """Entry in the session's patch list"""
     id: str  # e.g., "000001_a1b2c3d4"
     sequence: int
     milestone: str
@@ -93,11 +92,12 @@ class PatchEntry(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
-class WALManifest(BaseModel):
-    """Write-Ahead Log manifest"""
+class SessionInfo(BaseModel):
+    """Session information stored in session.json"""
     version: str = METADATA_VERSION
     session_id: str = ""
     created_at: str = ""
+    updated_at: str = ""
     patches: List[PatchEntry] = Field(default_factory=list)
 
     def get_next_sequence(self) -> int:
@@ -175,12 +175,12 @@ class CentralMetadata(BaseModel):
 
 class MetadataManager:
     """
-    Manages the .devdox_ai_locust/ directory with PostgreSQL WAL-inspired structure.
+    Manages the .devdox_ai_locust/ directory structure.
 
-    Simple, flat, extensible:
+    Structure:
     - metadata.json: Central config and API info
-    - manifest.json: WAL manifest mapping patches to milestones
-    - wal/: Directory of sequential patch files
+    - {session_id}/session.json: Session milestones info
+    - {session_id}/.patches/: Directory of sequential patch files
     """
 
     def __init__(self, output_dir: Path):
@@ -193,12 +193,14 @@ class MetadataManager:
         self.output_dir = Path(output_dir)
         self.devdox_dir = self.output_dir / DEVDOX_DIR_NAME
         self.metadata_path = self.devdox_dir / METADATA_FILENAME
-        self.manifest_path = self.devdox_dir / MANIFEST_FILENAME
-        self.wal_dir = self.devdox_dir / WAL_DIR
 
         self.session_id = ""
+        self._session_dir: Optional[Path] = None
+        self._patches_dir: Optional[Path] = None
+        self._session_path: Optional[Path] = None
+
         self.metadata = CentralMetadata()
-        self.manifest = WALManifest()
+        self.session_info = SessionInfo()
         self._start_time: Optional[datetime] = None
 
     # =========================================================================
@@ -208,7 +210,23 @@ class MetadataManager:
     def _ensure_directories(self) -> None:
         """Create directory structure if needed"""
         self.devdox_dir.mkdir(parents=True, exist_ok=True)
-        self.wal_dir.mkdir(exist_ok=True)
+        if self._session_dir:
+            self._session_dir.mkdir(parents=True, exist_ok=True)
+        if self._patches_dir:
+            self._patches_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def patches_dir(self) -> Path:
+        """Get the patches directory for the current session"""
+        if self._patches_dir:
+            return self._patches_dir
+        # Fallback for backwards compatibility
+        return self.devdox_dir / "patches"
+
+    @property
+    def manifest(self) -> SessionInfo:
+        """Backwards compatibility alias for session_info"""
+        return self.session_info
 
     # =========================================================================
     # Session Management
@@ -231,11 +249,17 @@ class MetadataManager:
         Returns:
             Session ID
         """
-        self._ensure_directories()
         self._start_time = datetime.now(timezone.utc)
 
-        # Generate session ID
+        # Generate session ID (datetime stamp)
         self.session_id = self._start_time.strftime("%Y-%m-%d_%H-%M-%S")
+
+        # Setup session directories
+        self._session_dir = self.devdox_dir / self.session_id
+        self._patches_dir = self._session_dir / PATCHES_DIR
+        self._session_path = self._session_dir / SESSION_FILENAME
+
+        self._ensure_directories()
 
         # Initialize metadata
         self.metadata = CentralMetadata(
@@ -255,22 +279,26 @@ class MetadataManager:
                 source_type=source_type,
             )
 
-        # Initialize manifest
-        self.manifest = WALManifest(
+        # Initialize session info
+        self.session_info = SessionInfo(
             session_id=self.session_id,
             created_at=self._start_time.isoformat(),
+            updated_at=self._start_time.isoformat(),
         )
 
-        # Load existing manifest if present (for incremental updates)
-        self._load_manifest()
+        # Load existing session if present (for incremental updates)
+        self._load_session()
 
         logger.info(f"Initialized session: {self.session_id}")
         return self.session_id
 
     def finalize_session(self) -> None:
         """Finalize the session and save all metadata"""
-        # Update timestamp
-        self.metadata.updated_at = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(timezone.utc).isoformat()
+
+        # Update timestamps
+        self.metadata.updated_at = now
+        self.session_info.updated_at = now
 
         # Calculate totals
         self.metadata.output.total_files = (
@@ -280,12 +308,12 @@ class MetadataManager:
 
         # Save everything
         self._save_metadata()
-        self._save_manifest()
+        self._save_session()
 
         logger.info(f"Finalized session: {self.session_id}")
 
     # =========================================================================
-    # Patch Management (WAL)
+    # Patch Management
     # =========================================================================
 
     def create_patch(
@@ -297,7 +325,7 @@ class MetadataManager:
         metadata: Optional[Dict[str, Any]] = None,
     ) -> PatchEntry:
         """
-        Create a new patch in the WAL.
+        Create a new patch in the session.
 
         Args:
             milestone: Type of milestone (template_generation, llm_enhancement, etc.)
@@ -311,8 +339,8 @@ class MetadataManager:
         """
         self._ensure_directories()
 
-        # Add to manifest
-        entry = self.manifest.add_patch(
+        # Add to session info
+        entry = self.session_info.add_patch(
             milestone=milestone,
             description=description,
             stats=stats,
@@ -320,11 +348,12 @@ class MetadataManager:
         )
 
         # Write patch file
-        patch_path = self.wal_dir / f"{entry.id}.patch"
-        patch_path.write_text(content, encoding="utf-8")
+        if self._patches_dir:
+            patch_path = self._patches_dir / f"{entry.id}.patch"
+            patch_path.write_text(content, encoding="utf-8")
 
-        # Save manifest
-        self._save_manifest()
+        # Save session info
+        self._save_session()
 
         logger.debug(f"Created patch: {entry.id} ({milestone})")
         return entry
@@ -339,25 +368,22 @@ class MetadataManager:
         Returns:
             Patch content or None if not found
         """
-        patch_path = self.wal_dir / f"{patch_id}.patch"
+        if not self._patches_dir:
+            return None
+        patch_path = self._patches_dir / f"{patch_id}.patch"
         if patch_path.exists():
             return patch_path.read_text(encoding="utf-8")
         return None
 
     def get_patches_by_milestone(self, milestone: str) -> List[PatchEntry]:
         """Get all patches for a specific milestone type"""
-        return [p for p in self.manifest.patches if p.milestone == milestone]
+        return [p for p in self.session_info.patches if p.milestone == milestone]
 
     def get_latest_patch(self) -> Optional[PatchEntry]:
         """Get the most recent patch entry"""
-        if self.manifest.patches:
-            return max(self.manifest.patches, key=lambda p: p.sequence)
+        if self.session_info.patches:
+            return max(self.session_info.patches, key=lambda p: p.sequence)
         return None
-
-    @property
-    def patches_dir(self) -> Path:
-        """Get the WAL directory (for backwards compatibility)"""
-        return self.wal_dir
 
     # =========================================================================
     # Configuration Updates
@@ -411,26 +437,29 @@ class MetadataManager:
             encoding="utf-8",
         )
 
-    def _save_manifest(self) -> None:
-        """Save WAL manifest to disk"""
+    def _save_session(self) -> None:
+        """Save session info to disk"""
+        if not self._session_path:
+            return
         self._ensure_directories()
-        self.manifest_path.write_text(
-            json.dumps(self.manifest.model_dump(), indent=2),
+        self._session_path.write_text(
+            json.dumps(self.session_info.model_dump(), indent=2),
             encoding="utf-8",
         )
 
-    def _load_manifest(self) -> None:
-        """Load existing manifest if present"""
-        if self.manifest_path.exists():
-            try:
-                data = json.loads(self.manifest_path.read_text(encoding="utf-8"))
-                # Preserve existing patches
-                if "patches" in data:
-                    for patch_data in data["patches"]:
-                        entry = PatchEntry(**patch_data)
-                        self.manifest.patches.append(entry)
-            except Exception as e:
-                logger.warning(f"Failed to load existing manifest: {e}")
+    def _load_session(self) -> None:
+        """Load existing session if present"""
+        if not self._session_path or not self._session_path.exists():
+            return
+        try:
+            data = json.loads(self._session_path.read_text(encoding="utf-8"))
+            # Preserve existing patches
+            if "patches" in data:
+                for patch_data in data["patches"]:
+                    entry = PatchEntry(**patch_data)
+                    self.session_info.patches.append(entry)
+        except Exception as e:
+            logger.warning(f"Failed to load existing session: {e}")
 
     # =========================================================================
     # Utility Methods
@@ -438,18 +467,18 @@ class MetadataManager:
 
     def get_structure_info(self) -> str:
         """Get a formatted string showing the directory structure"""
-        patch_count = len(self.manifest.patches)
+        patch_count = len(self.session_info.patches)
         return f"""
 .devdox_ai_locust/
-├── metadata.json       # Central metadata (API info, config)
-├── manifest.json       # WAL manifest ({patch_count} patches)
-└── wal/                # Write-Ahead Log
-    └── *.patch         # Sequential patch files
+├── metadata.json                    # Central metadata (API info, config)
+└── {self.session_id}/               # Session directory
+    ├── session.json                 # Milestones ({patch_count} patches)
+    └── .patches/                    # Patch files
 """
 
     def to_dict(self) -> Dict[str, Any]:
         """Export all data as dictionary"""
         return {
             "metadata": self.metadata.model_dump(),
-            "manifest": self.manifest.model_dump(),
+            "session": self.session_info.model_dump(),
         }

--- a/src/devdox_ai_locust/utils/metadata_manager.py
+++ b/src/devdox_ai_locust/utils/metadata_manager.py
@@ -1,64 +1,134 @@
 """
 Central Metadata Manager for DevDox AI Locust
 
-Manages the .devdox_ai_locust/ directory with a clear, organized structure.
-This is the single source of truth for all generated test information.
+PostgreSQL WAL-Inspired Structure (v3.0)
+========================================
+
+Simple, flat, extensible design inspired by PostgreSQL's Write-Ahead Log.
 
 Directory Structure:
     .devdox_ai_locust/
-    ├── metadata.json                    # Central metadata file (main index)
-    │
-    ├── generation/                      # Generation-related data
-    │   └── sessions/                    # Historical session data
-    │       └── {session_id}/
-    │           └── config.json          # Session-specific config
-    │
-    ├── ai_enhancement/                  # AI enhancement tracking
-    │   ├── patches/                     # Pre/post LLM code patches
-    │   │   └── {session_id}/
-    │   │       ├── pre_llm.patch        # Code before AI enhancement
-    │   │       ├── post_llm.patch       # Code after AI enhancement
-    │   │       └── summary.json         # Patch statistics
-    │   │
-    │   └── constraints/                 # AI sandbox constraints used
-    │       └── {session_id}/
-    │           ├── test_data.txt        # Constraints for test_data.py
-    │           └── utils.txt            # Constraints for utils.py
-    │
-    ├── codebase_analysis/               # CodebaseAwareness outputs
-    │   └── {session_id}/
-    │       ├── dependencies.json        # File dependency map
-    │       ├── protected_symbols.json   # Protected symbols per file
-    │       └── exports.json             # Exports per file
-    │
-    └── logs/                            # Generation logs
-        └── {session_id}.log
+    ├── metadata.json       # Central metadata (API info, config)
+    ├── manifest.json       # WAL manifest - maps patches to milestones
+    └── wal/                # Write-Ahead Log - sequential patches
+        ├── 000001_a1b2c3d4.patch
+        ├── 000002_e5f6g7h8.patch
+        └── 000003_i9j0k1l2.patch
+
+Key Concepts:
+    - Each code change milestone gets a sequential patch file
+    - Patches are named: {sequence}_{short_uuid}.patch
+    - manifest.json tracks what each patch represents
+    - Milestones can be: template_generation, llm_enhancement, validation, etc.
+    - Extensible for future milestones (user_edit, refactor, etc.)
+
+Example manifest.json:
+    {
+        "version": "3.0",
+        "session_id": "2025-12-29_10-39-24",
+        "patches": [
+            {
+                "id": "000001_a1b2c3d4",
+                "sequence": 1,
+                "milestone": "template_generation",
+                "description": "Initial template-based generation",
+                "created_at": "2025-12-29T10:39:24Z",
+                "stats": {"files_changed": 8, "additions": 450, "deletions": 0}
+            },
+            {
+                "id": "000002_e5f6g7h8",
+                "sequence": 2,
+                "milestone": "llm_enhancement",
+                "description": "AI enhancement of test files",
+                "created_at": "2025-12-29T10:40:15Z",
+                "stats": {"files_changed": 3, "additions": 120, "deletions": 15}
+            }
+        ]
+    }
 """
 
 import json
+import uuid
 import logging
 from pathlib import Path
 from datetime import datetime, timezone
-from typing import Dict, Any, Optional, List, Protocol, Set
+from typing import Dict, Any, Optional, List
 from pydantic import BaseModel, Field
 from enum import Enum
 
 logger = logging.getLogger(__name__)
 
-METADATA_VERSION = "2.0"
+METADATA_VERSION = "3.0"
 METADATA_FILENAME = "metadata.json"
+MANIFEST_FILENAME = "manifest.json"
+WAL_DIR = "wal"
 DEVDOX_DIR_NAME = ".devdox_ai_locust"
 
 
-class SubDirectory(str, Enum):
-    """Subdirectories within .devdox_ai_locust/"""
-    GENERATION = "generation"
-    GENERATION_SESSIONS = "generation/sessions"
-    AI_ENHANCEMENT = "ai_enhancement"
-    AI_PATCHES = "ai_enhancement/patches"
-    AI_CONSTRAINTS = "ai_enhancement/constraints"
-    CODEBASE_ANALYSIS = "codebase_analysis"
-    LOGS = "logs"
+class Milestone(str, Enum):
+    """Types of code change milestones"""
+    TEMPLATE_GENERATION = "template_generation"
+    LLM_ENHANCEMENT = "llm_enhancement"
+    VALIDATION = "validation"
+    USER_EDIT = "user_edit"
+    REFACTOR = "refactor"
+    MERGE = "merge"
+
+
+class PatchStats(BaseModel):
+    """Statistics for a patch"""
+    files_changed: int = 0
+    additions: int = 0
+    deletions: int = 0
+
+
+class PatchEntry(BaseModel):
+    """Entry in the WAL manifest"""
+    id: str  # e.g., "000001_a1b2c3d4"
+    sequence: int
+    milestone: str
+    description: str = ""
+    created_at: str
+    stats: PatchStats = Field(default_factory=PatchStats)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class WALManifest(BaseModel):
+    """Write-Ahead Log manifest"""
+    version: str = METADATA_VERSION
+    session_id: str = ""
+    created_at: str = ""
+    patches: List[PatchEntry] = Field(default_factory=list)
+
+    def get_next_sequence(self) -> int:
+        """Get next patch sequence number"""
+        if not self.patches:
+            return 1
+        return max(p.sequence for p in self.patches) + 1
+
+    def add_patch(
+        self,
+        milestone: str,
+        description: str = "",
+        stats: Optional[PatchStats] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> PatchEntry:
+        """Add a new patch entry"""
+        sequence = self.get_next_sequence()
+        short_uuid = uuid.uuid4().hex[:8]
+        patch_id = f"{sequence:06d}_{short_uuid}"
+
+        entry = PatchEntry(
+            id=patch_id,
+            sequence=sequence,
+            milestone=milestone,
+            description=description,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            stats=stats or PatchStats(),
+            metadata=metadata or {},
+        )
+        self.patches.append(entry)
+        return entry
 
 
 class APIMetadata(BaseModel):
@@ -69,640 +139,317 @@ class APIMetadata(BaseModel):
     description: str = ""
     endpoints_count: int = 0
     swagger_source: str = ""
-    source_type: str = ""  # "url" or "file"
+    source_type: str = ""
 
 
-class GenerationMetadata(BaseModel):
-    """Metadata about the generation session"""
-    session_id: str = ""
-    created_at: str = ""
+class GenerationConfig(BaseModel):
+    """Configuration used for generation"""
     host: str = ""
     auth_enabled: bool = True
     db_type: str = ""
-    custom_requirement: str = ""
-    processing_time_seconds: float = 0.0
     ai_model: str = ""
-    enhancements_applied: List[str] = Field(default_factory=list)
-    errors: List[str] = Field(default_factory=list)
+    custom_requirement: str = ""
 
 
-class OutputMetadata(BaseModel):
-    """Metadata about generated output files"""
+class OutputInfo(BaseModel):
+    """Information about generated output"""
     directory: str = ""
     main_files: List[str] = Field(default_factory=list)
     workflow_files: List[str] = Field(default_factory=list)
     total_files: int = 0
 
 
-class PatchSessionInfo(BaseModel):
-    """Information about a patch session"""
-    session_id: str
-    created_at: str
-    pre_llm_files: int = 0
-    post_llm_files: int = 0
-    files_changed: int = 0
-    files_added: int = 0
-    files_removed: int = 0
-
-
-class AIEnhancementMetadata(BaseModel):
-    """Metadata for AI enhancement feature"""
-    enabled: bool = True
-    total_sessions: int = 0
-    latest_session: str = ""
-    sessions: List[str] = Field(default_factory=list)
-
-
-class CodebaseAnalysisMetadata(BaseModel):
-    """Metadata for codebase analysis feature"""
-    enabled: bool = True
-    latest_session: str = ""
-    total_protected_symbols: int = 0
-
-
-class FeaturesMetadata(BaseModel):
-    """Container for all extensible features"""
-    ai_enhancement: AIEnhancementMetadata = Field(default_factory=AIEnhancementMetadata)
-    codebase_analysis: CodebaseAnalysisMetadata = Field(default_factory=CodebaseAnalysisMetadata)
-
-
 class CentralMetadata(BaseModel):
     """
     Central metadata structure for DevDox AI Locust.
-
-    This is the main data structure stored in .devdox_ai_locust/metadata.json.
-    It provides a high-level overview; detailed data is in subdirectories.
+    Stored in .devdox_ai_locust/metadata.json
     """
     version: str = METADATA_VERSION
+    session_id: str = ""
     created_at: str = ""
     updated_at: str = ""
     api: APIMetadata = Field(default_factory=APIMetadata)
-    generation: GenerationMetadata = Field(default_factory=GenerationMetadata)
-    output: OutputMetadata = Field(default_factory=OutputMetadata)
-    features: FeaturesMetadata = Field(default_factory=FeaturesMetadata)
-
-
-class MetadataStorageProtocol(Protocol):
-    """Protocol for metadata storage backends (allows dependency injection)"""
-
-    def load(self) -> Optional[CentralMetadata]:
-        """Load metadata from storage"""
-        ...
-
-    def save(self, metadata: CentralMetadata) -> Path:
-        """Save metadata to storage"""
-        ...
-
-    def exists(self) -> bool:
-        """Check if metadata exists"""
-        ...
-
-    def get_devdox_dir(self) -> Path:
-        """Get the .devdox_ai_locust directory path"""
-        ...
-
-
-class FileSystemMetadataStorage:
-    """File system based metadata storage"""
-
-    def __init__(self, output_dir: Path):
-        self.output_dir = Path(output_dir)
-        self.devdox_dir = self.output_dir / DEVDOX_DIR_NAME
-        self.metadata_path = self.devdox_dir / METADATA_FILENAME
-
-    def _ensure_dir(self) -> Path:
-        """Ensure .devdox_ai_locust directory exists"""
-        self.devdox_dir.mkdir(parents=True, exist_ok=True)
-        return self.devdox_dir
-
-    def get_devdox_dir(self) -> Path:
-        """Get the .devdox_ai_locust directory path"""
-        return self._ensure_dir()
-
-    def exists(self) -> bool:
-        """Check if metadata file exists"""
-        return self.metadata_path.exists()
-
-    def load(self) -> Optional[CentralMetadata]:
-        """Load metadata from file"""
-        if not self.exists():
-            return None
-
-        try:
-            with open(self.metadata_path, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-
-            # Reconstruct the dataclass structure
-            return self._dict_to_metadata(data)
-        except Exception as e:
-            logger.warning(f"Failed to load metadata: {e}")
-            return None
-
-    def save(self, metadata: CentralMetadata) -> Path:
-        """Save metadata to file"""
-        self._ensure_dir()
-
-        # Update the updated_at timestamp
-        metadata.updated_at = datetime.now(timezone.utc).isoformat()
-
-        # Convert to dict and save
-        data = self._metadata_to_dict(metadata)
-
-        with open(self.metadata_path, 'w', encoding='utf-8') as f:
-            json.dump(data, f, indent=2, default=str)
-
-        logger.debug(f"Saved metadata to: {self.metadata_path}")
-        return self.metadata_path
-
-    def _metadata_to_dict(self, metadata: CentralMetadata) -> Dict[str, Any]:
-        """Convert CentralMetadata to dictionary"""
-        return metadata.model_dump()
-
-    def _dict_to_metadata(self, data: Dict[str, Any]) -> CentralMetadata:
-        """Convert dictionary to CentralMetadata"""
-        # Handle nested dataclasses
-        api_data = data.get('api', {})
-        api = APIMetadata(**api_data) if api_data else APIMetadata()
-
-        gen_data = data.get('generation', {})
-        generation = GenerationMetadata(**gen_data) if gen_data else GenerationMetadata()
-
-        output_data = data.get('output', {})
-        output = OutputMetadata(**output_data) if output_data else OutputMetadata()
-
-        features_data = data.get('features', {})
-
-        # Handle AI enhancement metadata
-        ai_data = features_data.get('ai_enhancement', {})
-        ai_enhancement = AIEnhancementMetadata(**ai_data) if ai_data else AIEnhancementMetadata()
-
-        # Handle codebase analysis metadata
-        codebase_data = features_data.get('codebase_analysis', {})
-        codebase_analysis = CodebaseAnalysisMetadata(**codebase_data) if codebase_data else CodebaseAnalysisMetadata()
-
-        features = FeaturesMetadata(
-            ai_enhancement=ai_enhancement,
-            codebase_analysis=codebase_analysis
-        )
-
-        return CentralMetadata(
-            version=data.get('version', METADATA_VERSION),
-            created_at=data.get('created_at', ''),
-            updated_at=data.get('updated_at', ''),
-            api=api,
-            generation=generation,
-            output=output,
-            features=features
-        )
+    config: GenerationConfig = Field(default_factory=GenerationConfig)
+    output: OutputInfo = Field(default_factory=OutputInfo)
 
 
 class MetadataManager:
     """
-    Central manager for .devdox_ai_locust/ metadata.
+    Manages the .devdox_ai_locust/ directory with PostgreSQL WAL-inspired structure.
 
-    This is the main interface for the generate command and other features
-    to interact with the metadata system.
-
-    Usage:
-        manager = MetadataManager(output_dir)
-        manager.initialize_session(api_info, swagger_source)
-
-        # During generation
-        manager.update_generation_info(host=host, auth=auth)
-
-        # After generation
-        manager.register_files(main_files, workflow_files)
-        manager.finalize_session(processing_time, ai_model, enhancements)
+    Simple, flat, extensible:
+    - metadata.json: Central config and API info
+    - manifest.json: WAL manifest mapping patches to milestones
+    - wal/: Directory of sequential patch files
     """
 
-    def __init__(
-        self,
-        output_dir: Path,
-        storage: Optional[MetadataStorageProtocol] = None
-    ):
-        self.output_dir = Path(output_dir)
-        self.storage = storage or FileSystemMetadataStorage(self.output_dir)
-        self._metadata: Optional[CentralMetadata] = None
-        self._session_start_time: Optional[datetime] = None
-        self._current_session_id: Optional[str] = None
-
-    @property
-    def metadata(self) -> CentralMetadata:
-        """Get current metadata, loading from storage if needed"""
-        if self._metadata is None:
-            self._metadata = self.storage.load() or CentralMetadata()
-        return self._metadata
-
-    @property
-    def devdox_dir(self) -> Path:
-        """Get the .devdox_ai_locust directory path"""
-        return self.storage.get_devdox_dir()
-
-    @property
-    def session_id(self) -> str:
-        """Get the current session ID"""
-        return self._current_session_id or self.generate_session_id()
-
-    # =========================================================================
-    # Directory Access Methods
-    # =========================================================================
-
-    def get_subdir(self, subdir: SubDirectory, session_id: Optional[str] = None) -> Path:
+    def __init__(self, output_dir: Path):
         """
-        Get a subdirectory path within .devdox_ai_locust/
+        Initialize metadata manager.
 
         Args:
-            subdir: The subdirectory type
-            session_id: Optional session ID for session-specific subdirs
-
-        Returns:
-            Path to the subdirectory (created if needed)
+            output_dir: Directory where .devdox_ai_locust will be created
         """
-        path = self.devdox_dir / subdir.value
-        if session_id:
-            path = path / session_id
-        path.mkdir(parents=True, exist_ok=True)
-        return path
+        self.output_dir = Path(output_dir)
+        self.devdox_dir = self.output_dir / DEVDOX_DIR_NAME
+        self.metadata_path = self.devdox_dir / METADATA_FILENAME
+        self.manifest_path = self.devdox_dir / MANIFEST_FILENAME
+        self.wal_dir = self.devdox_dir / WAL_DIR
 
-    def get_patches_dir(self, session_id: Optional[str] = None) -> Path:
-        """Get the AI patches directory for a session"""
-        return self.get_subdir(SubDirectory.AI_PATCHES, session_id or self.session_id)
+        self.session_id = ""
+        self.metadata = CentralMetadata()
+        self.manifest = WALManifest()
+        self._start_time: Optional[datetime] = None
 
-    def get_constraints_dir(self, session_id: Optional[str] = None) -> Path:
-        """Get the AI constraints directory for a session"""
-        return self.get_subdir(SubDirectory.AI_CONSTRAINTS, session_id or self.session_id)
+    # =========================================================================
+    # Directory Setup
+    # =========================================================================
 
-    def get_codebase_analysis_dir(self, session_id: Optional[str] = None) -> Path:
-        """Get the codebase analysis directory for a session"""
-        return self.get_subdir(SubDirectory.CODEBASE_ANALYSIS, session_id or self.session_id)
-
-    def get_generation_session_dir(self, session_id: Optional[str] = None) -> Path:
-        """Get the generation session directory"""
-        return self.get_subdir(SubDirectory.GENERATION_SESSIONS, session_id or self.session_id)
-
-    def get_logs_dir(self) -> Path:
-        """Get the logs directory"""
-        return self.get_subdir(SubDirectory.LOGS)
-
-    # Backwards compatibility
-    @property
-    def patches_dir(self) -> Path:
-        """Get the patches subdirectory path (backwards compatible)"""
-        return self.get_patches_dir()
+    def _ensure_directories(self) -> None:
+        """Create directory structure if needed"""
+        self.devdox_dir.mkdir(parents=True, exist_ok=True)
+        self.wal_dir.mkdir(exist_ok=True)
 
     # =========================================================================
     # Session Management
     # =========================================================================
 
-    def generate_session_id(self) -> str:
-        """Generate a timestamped session ID"""
-        return datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-
     def initialize_session(
         self,
         api_info: Optional[Dict[str, Any]] = None,
         swagger_source: str = "",
-        source_type: str = ""
+        source_type: str = "",
     ) -> str:
         """
         Initialize a new generation session.
 
         Args:
-            api_info: API information from OpenAPI parser
-            swagger_source: URL or file path of the swagger source
+            api_info: API metadata from swagger
+            swagger_source: Source of swagger (URL or file path)
             source_type: "url" or "file"
 
         Returns:
             Session ID
         """
-        self._current_session_id = self.generate_session_id()
-        self._session_start_time = datetime.now(timezone.utc)
+        self._ensure_directories()
+        self._start_time = datetime.now(timezone.utc)
 
-        # Load existing metadata or create new
-        self._metadata = self.storage.load() or CentralMetadata()
+        # Generate session ID
+        self.session_id = self._start_time.strftime("%Y-%m-%d_%H-%M-%S")
 
-        # Set creation timestamp if new
-        if not self._metadata.created_at:
-            self._metadata.created_at = self._session_start_time.isoformat()
-
-        # Update API metadata
-        if api_info:
-            self._metadata.api = APIMetadata(
-                title=api_info.get('title', 'Unknown'),
-                version=api_info.get('version', 'Unknown'),
-                base_url=api_info.get('base_url', ''),
-                description=api_info.get('description', ''),
-                endpoints_count=api_info.get('endpoints_count', 0),
-                swagger_source=swagger_source,
-                source_type=source_type
-            )
-
-        # Initialize generation metadata
-        self._metadata.generation = GenerationMetadata(
-            session_id=self._current_session_id,
-            created_at=self._session_start_time.isoformat()
+        # Initialize metadata
+        self.metadata = CentralMetadata(
+            session_id=self.session_id,
+            created_at=self._start_time.isoformat(),
+            updated_at=self._start_time.isoformat(),
         )
 
-        # Set output directory
-        self._metadata.output.directory = str(self.output_dir.absolute())
+        # Set API info
+        if api_info:
+            self.metadata.api = APIMetadata(
+                title=api_info.get("title", "Unknown"),
+                version=api_info.get("version", "Unknown"),
+                base_url=api_info.get("base_url", ""),
+                description=api_info.get("description", ""),
+                swagger_source=swagger_source,
+                source_type=source_type,
+            )
 
-        logger.info(f"Initialized metadata session: {self._current_session_id}")
-        return self._current_session_id
+        # Initialize manifest
+        self.manifest = WALManifest(
+            session_id=self.session_id,
+            created_at=self._start_time.isoformat(),
+        )
+
+        # Load existing manifest if present (for incremental updates)
+        self._load_manifest()
+
+        logger.info(f"Initialized session: {self.session_id}")
+        return self.session_id
+
+    def finalize_session(self) -> None:
+        """Finalize the session and save all metadata"""
+        # Update timestamp
+        self.metadata.updated_at = datetime.now(timezone.utc).isoformat()
+
+        # Calculate totals
+        self.metadata.output.total_files = (
+            len(self.metadata.output.main_files) +
+            len(self.metadata.output.workflow_files)
+        )
+
+        # Save everything
+        self._save_metadata()
+        self._save_manifest()
+
+        logger.info(f"Finalized session: {self.session_id}")
+
+    # =========================================================================
+    # Patch Management (WAL)
+    # =========================================================================
+
+    def create_patch(
+        self,
+        milestone: str,
+        content: str,
+        description: str = "",
+        stats: Optional[PatchStats] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> PatchEntry:
+        """
+        Create a new patch in the WAL.
+
+        Args:
+            milestone: Type of milestone (template_generation, llm_enhancement, etc.)
+            content: Patch content (unified diff format)
+            description: Human-readable description
+            stats: Patch statistics
+            metadata: Additional metadata
+
+        Returns:
+            PatchEntry for the created patch
+        """
+        self._ensure_directories()
+
+        # Add to manifest
+        entry = self.manifest.add_patch(
+            milestone=milestone,
+            description=description,
+            stats=stats,
+            metadata=metadata,
+        )
+
+        # Write patch file
+        patch_path = self.wal_dir / f"{entry.id}.patch"
+        patch_path.write_text(content, encoding="utf-8")
+
+        # Save manifest
+        self._save_manifest()
+
+        logger.debug(f"Created patch: {entry.id} ({milestone})")
+        return entry
+
+    def get_patch(self, patch_id: str) -> Optional[str]:
+        """
+        Read a patch by ID.
+
+        Args:
+            patch_id: Patch ID (e.g., "000001_a1b2c3d4")
+
+        Returns:
+            Patch content or None if not found
+        """
+        patch_path = self.wal_dir / f"{patch_id}.patch"
+        if patch_path.exists():
+            return patch_path.read_text(encoding="utf-8")
+        return None
+
+    def get_patches_by_milestone(self, milestone: str) -> List[PatchEntry]:
+        """Get all patches for a specific milestone type"""
+        return [p for p in self.manifest.patches if p.milestone == milestone]
+
+    def get_latest_patch(self) -> Optional[PatchEntry]:
+        """Get the most recent patch entry"""
+        if self.manifest.patches:
+            return max(self.manifest.patches, key=lambda p: p.sequence)
+        return None
+
+    @property
+    def patches_dir(self) -> Path:
+        """Get the WAL directory (for backwards compatibility)"""
+        return self.wal_dir
+
+    # =========================================================================
+    # Configuration Updates
+    # =========================================================================
+
+    def update_api_endpoints_count(self, count: int) -> None:
+        """Update the endpoints count"""
+        self.metadata.api.endpoints_count = count
 
     def update_generation_config(
         self,
         host: Optional[str] = None,
         auth_enabled: Optional[bool] = None,
         db_type: Optional[str] = None,
+        ai_model: Optional[str] = None,
         custom_requirement: Optional[str] = None,
-        ai_model: Optional[str] = None
     ) -> None:
-        """Update generation configuration in metadata"""
-        gen = self.metadata.generation
-
+        """Update generation configuration"""
         if host is not None:
-            gen.host = host
+            self.metadata.config.host = host
         if auth_enabled is not None:
-            gen.auth_enabled = auth_enabled
+            self.metadata.config.auth_enabled = auth_enabled
         if db_type is not None:
-            gen.db_type = db_type
-        if custom_requirement is not None:
-            gen.custom_requirement = custom_requirement
+            self.metadata.config.db_type = db_type
         if ai_model is not None:
-            gen.ai_model = ai_model
-
-    def update_api_endpoints_count(self, count: int) -> None:
-        """Update the endpoints count"""
-        self.metadata.api.endpoints_count = count
+            self.metadata.config.ai_model = ai_model
+        if custom_requirement is not None:
+            self.metadata.config.custom_requirement = custom_requirement
 
     def register_files(
         self,
         main_files: Optional[List[str]] = None,
-        workflow_files: Optional[List[str]] = None
+        workflow_files: Optional[List[str]] = None,
     ) -> None:
-        """Register generated files in metadata"""
-        output = self.metadata.output
-
+        """Register generated files"""
         if main_files:
-            output.main_files = main_files
+            self.metadata.output.main_files = main_files
         if workflow_files:
-            output.workflow_files = workflow_files
-
-        output.total_files = len(output.main_files) + len(output.workflow_files)
-
-    # =========================================================================
-    # AI Enhancement Tracking
-    # =========================================================================
-
-    def save_patch_summary(
-        self,
-        pre_llm_files: int,
-        post_llm_files: int,
-        files_changed: int,
-        files_added: int = 0,
-        files_removed: int = 0,
-        patches: Optional[Dict[str, str]] = None
-    ) -> Path:
-        """
-        Save patch summary to the patches directory.
-
-        Args:
-            pre_llm_files: Number of files before LLM
-            post_llm_files: Number of files after LLM
-            files_changed: Number of files changed
-            files_added: Number of files added
-            files_removed: Number of files removed
-            patches: Dict of filename -> unified diff
-
-        Returns:
-            Path to the summary file
-        """
-        patches_dir = self.get_patches_dir()
-
-        summary = {
-            "session_id": self.session_id,
-            "created_at": datetime.now(timezone.utc).isoformat(),
-            "pre_llm_files_count": pre_llm_files,
-            "post_llm_files_count": post_llm_files,
-            "files_changed": files_changed,
-            "files_added": files_added,
-            "files_removed": files_removed,
-        }
-
-        # Save summary
-        summary_path = patches_dir / "summary.json"
-        with open(summary_path, 'w', encoding='utf-8') as f:
-            json.dump(summary, f, indent=2)
-
-        # Save patches if provided
-        if patches:
-            patches_file = patches_dir / "patches.json"
-            with open(patches_file, 'w', encoding='utf-8') as f:
-                json.dump(patches, f, indent=2)
-
-        # Update metadata
-        ai_meta = self.metadata.features.ai_enhancement
-        ai_meta.enabled = True
-        ai_meta.total_sessions += 1
-        ai_meta.latest_session = self.session_id
-        if self.session_id not in ai_meta.sessions:
-            ai_meta.sessions.append(self.session_id)
-
-        logger.info(f"Saved patch summary to: {patches_dir}")
-        return summary_path
-
-    def save_constraints(
-        self,
-        filename: str,
-        constraints: str
-    ) -> Path:
-        """
-        Save AI constraints used for a file.
-
-        Args:
-            filename: The file the constraints were for (e.g., "test_data.py")
-            constraints: The constraint text sent to AI
-
-        Returns:
-            Path to the saved constraints file
-        """
-        constraints_dir = self.get_constraints_dir()
-
-        # Clean filename for saving
-        clean_name = filename.replace('.py', '').replace('/', '_')
-        constraints_path = constraints_dir / f"{clean_name}.constraints.txt"
-
-        with open(constraints_path, 'w', encoding='utf-8') as f:
-            f.write(f"# Constraints for {filename}\n")
-            f.write(f"# Session: {self.session_id}\n")
-            f.write(f"# Generated: {datetime.now(timezone.utc).isoformat()}\n")
-            f.write("\n")
-            f.write(constraints)
-
-        logger.debug(f"Saved constraints for {filename} to: {constraints_path}")
-        return constraints_path
+            self.metadata.output.workflow_files = workflow_files
+        self.metadata.output.directory = str(self.output_dir)
 
     # =========================================================================
-    # Codebase Analysis Storage
+    # Persistence
     # =========================================================================
 
-    def save_codebase_analysis(
-        self,
-        exports: Dict[str, List[str]],
-        imports: Dict[str, Dict[str, List[str]]],
-        protected_symbols: Dict[str, List[Dict[str, Any]]]
-    ) -> Path:
-        """
-        Save codebase analysis results.
+    def _save_metadata(self) -> None:
+        """Save central metadata to disk"""
+        self._ensure_directories()
+        self.metadata_path.write_text(
+            json.dumps(self.metadata.model_dump(), indent=2),
+            encoding="utf-8",
+        )
 
-        Args:
-            exports: Dict of filename -> list of exported symbols
-            imports: Dict of filename -> {source_file: imported_symbols}
-            protected_symbols: Dict of filename -> list of protected symbol info
+    def _save_manifest(self) -> None:
+        """Save WAL manifest to disk"""
+        self._ensure_directories()
+        self.manifest_path.write_text(
+            json.dumps(self.manifest.model_dump(), indent=2),
+            encoding="utf-8",
+        )
 
-        Returns:
-            Path to the analysis directory
-        """
-        analysis_dir = self.get_codebase_analysis_dir()
-
-        # Save exports
-        exports_path = analysis_dir / "exports.json"
-        with open(exports_path, 'w', encoding='utf-8') as f:
-            json.dump({
-                "session_id": self.session_id,
-                "generated_at": datetime.now(timezone.utc).isoformat(),
-                "files": {k: list(v) if isinstance(v, set) else v for k, v in exports.items()}
-            }, f, indent=2)
-
-        # Save dependencies (imports)
-        deps_path = analysis_dir / "dependencies.json"
-        with open(deps_path, 'w', encoding='utf-8') as f:
-            json.dump({
-                "session_id": self.session_id,
-                "generated_at": datetime.now(timezone.utc).isoformat(),
-                "imports": {
-                    k: {sk: list(sv) if isinstance(sv, set) else sv for sk, sv in v.items()}
-                    for k, v in imports.items()
-                }
-            }, f, indent=2)
-
-        # Save protected symbols
-        protected_path = analysis_dir / "protected_symbols.json"
-        total_protected = sum(len(v) for v in protected_symbols.values())
-        with open(protected_path, 'w', encoding='utf-8') as f:
-            json.dump({
-                "session_id": self.session_id,
-                "generated_at": datetime.now(timezone.utc).isoformat(),
-                "total_protected_symbols": total_protected,
-                "by_file": protected_symbols
-            }, f, indent=2)
-
-        # Update metadata
-        codebase_meta = self.metadata.features.codebase_analysis
-        codebase_meta.enabled = True
-        codebase_meta.latest_session = self.session_id
-        codebase_meta.total_protected_symbols = total_protected
-
-        logger.info(f"Saved codebase analysis to: {analysis_dir}")
-        return analysis_dir
+    def _load_manifest(self) -> None:
+        """Load existing manifest if present"""
+        if self.manifest_path.exists():
+            try:
+                data = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+                # Preserve existing patches
+                if "patches" in data:
+                    for patch_data in data["patches"]:
+                        entry = PatchEntry(**patch_data)
+                        self.manifest.patches.append(entry)
+            except Exception as e:
+                logger.warning(f"Failed to load existing manifest: {e}")
 
     # =========================================================================
-    # Backwards Compatibility
-    # =========================================================================
-
-    def register_patch_session(self, patch_session_id: str) -> None:
-        """Register a patch tracking session (backwards compatible)"""
-        ai_meta = self.metadata.features.ai_enhancement
-        ai_meta.enabled = True
-
-        if patch_session_id not in ai_meta.sessions:
-            ai_meta.sessions.append(patch_session_id)
-
-        ai_meta.latest_session = patch_session_id
-        ai_meta.total_sessions = len(ai_meta.sessions)
-
-    # =========================================================================
-    # Enhancement and Error Tracking
-    # =========================================================================
-
-    def add_enhancement(self, enhancement: str) -> None:
-        """Add an enhancement to the list"""
-        if enhancement not in self.metadata.generation.enhancements_applied:
-            self.metadata.generation.enhancements_applied.append(enhancement)
-
-    def add_error(self, error: str) -> None:
-        """Add an error to the list"""
-        self.metadata.generation.errors.append(error)
-
-    # =========================================================================
-    # Session Finalization
-    # =========================================================================
-
-    def finalize_session(
-        self,
-        enhancements_applied: Optional[List[str]] = None,
-        errors: Optional[List[str]] = None
-    ) -> CentralMetadata:
-        """
-        Finalize the session and save metadata.
-
-        Args:
-            enhancements_applied: List of enhancements that were applied
-            errors: List of errors that occurred
-
-        Returns:
-            The finalized CentralMetadata
-        """
-        # Calculate processing time
-        if self._session_start_time:
-            processing_time = (
-                datetime.now(timezone.utc) - self._session_start_time
-            ).total_seconds()
-            self.metadata.generation.processing_time_seconds = processing_time
-
-        # Update enhancements and errors
-        if enhancements_applied:
-            self.metadata.generation.enhancements_applied = enhancements_applied
-        if errors:
-            self.metadata.generation.errors = errors
-
-        # Save to storage
-        self.storage.save(self.metadata)
-
-        logger.info(f"Finalized metadata session: {self.metadata.generation.session_id}")
-        return self.metadata
-
-    def get_file_paths(self) -> Dict[str, List[Path]]:
-        """Get full paths to all registered files"""
-        output_dir = Path(self.metadata.output.directory)
-
-        return {
-            'main_files': [
-                output_dir / f for f in self.metadata.output.main_files
-            ],
-            'workflow_files': [
-                output_dir / f for f in self.metadata.output.workflow_files
-            ]
-        }
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Export metadata as dictionary"""
-        return self.metadata.model_dump()
-
-    # =========================================================================
-    # Directory Structure Info
+    # Utility Methods
     # =========================================================================
 
     def get_structure_info(self) -> str:
         """Get a formatted string showing the directory structure"""
+        patch_count = len(self.manifest.patches)
         return f"""
 .devdox_ai_locust/
-├── metadata.json                         # Central metadata
-├── generation/
-│   └── sessions/{self.session_id}/       # Current session
-├── ai_enhancement/
-│   ├── patches/{self.session_id}/        # Code patches (pre/post LLM)
-│   └── constraints/{self.session_id}/    # AI sandbox constraints
-├── codebase_analysis/{self.session_id}/  # Dependency analysis
-└── logs/                                 # Generation logs
+├── metadata.json       # Central metadata (API info, config)
+├── manifest.json       # WAL manifest ({patch_count} patches)
+└── wal/                # Write-Ahead Log
+    └── *.patch         # Sequential patch files
 """
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Export all data as dictionary"""
+        return {
+            "metadata": self.metadata.model_dump(),
+            "manifest": self.manifest.model_dump(),
+        }

--- a/src/devdox_ai_locust/utils/metadata_manager.py
+++ b/src/devdox_ai_locust/utils/metadata_manager.py
@@ -151,12 +151,38 @@ class GenerationConfig(BaseModel):
     custom_requirement: str = ""
 
 
-class OutputInfo(BaseModel):
-    """Information about generated output"""
-    directory: str = ""
-    main_files: List[str] = Field(default_factory=list)
-    workflow_files: List[str] = Field(default_factory=list)
+class FileEntry(BaseModel):
+    """Metadata for a single generated file"""
+    category: str = "main"  # main, workflow, config, data, docs
+    size_bytes: int = 0
+    lines: int = 0
+    description: str = ""
+
+
+class OutputSummary(BaseModel):
+    """Summary statistics for output"""
     total_files: int = 0
+    total_bytes: int = 0
+    by_category: Dict[str, int] = Field(default_factory=dict)
+
+
+class OutputInfo(BaseModel):
+    """
+    Information about generated output with file tree structure.
+
+    Structure:
+        {
+            "root": "locust_tests_iter_7",
+            "files": {
+                "locustfile.py": {"category": "main", "size_bytes": 1234, ...},
+                "workflows/base_workflow.py": {"category": "workflow", ...}
+            },
+            "summary": {"total_files": 14, "total_bytes": 15000, ...}
+        }
+    """
+    root: str = ""
+    files: Dict[str, FileEntry] = Field(default_factory=dict)
+    summary: OutputSummary = Field(default_factory=OutputSummary)
 
 
 class CentralMetadata(BaseModel):
@@ -300,11 +326,8 @@ class MetadataManager:
         self.metadata.updated_at = now
         self.session_info.updated_at = now
 
-        # Calculate totals
-        self.metadata.output.total_files = (
-            len(self.metadata.output.main_files) +
-            len(self.metadata.output.workflow_files)
-        )
+        # Calculate output summary
+        self._calculate_output_summary()
 
         # Save everything
         self._save_metadata()
@@ -413,17 +436,63 @@ class MetadataManager:
         if custom_requirement is not None:
             self.metadata.config.custom_requirement = custom_requirement
 
+    def register_file(
+        self,
+        path: str,
+        content: str,
+        category: str = "main",
+        description: str = "",
+    ) -> None:
+        """
+        Register a single generated file with metadata.
+
+        Args:
+            path: Relative path from output root (e.g., "workflows/base.py")
+            content: File content (used to calculate size and lines)
+            category: File category (main, workflow, config, data, docs)
+            description: Optional description of the file
+        """
+        entry = FileEntry(
+            category=category,
+            size_bytes=len(content.encode("utf-8")),
+            lines=content.count("\n") + (1 if content and not content.endswith("\n") else 0),
+            description=description,
+        )
+        self.metadata.output.files[path] = entry
+
     def register_files(
         self,
-        main_files: Optional[List[str]] = None,
-        workflow_files: Optional[List[str]] = None,
+        files: Dict[str, str],
+        category: str = "main",
     ) -> None:
-        """Register generated files"""
-        if main_files:
-            self.metadata.output.main_files = main_files
-        if workflow_files:
-            self.metadata.output.workflow_files = workflow_files
-        self.metadata.output.directory = str(self.output_dir)
+        """
+        Register multiple files at once.
+
+        Args:
+            files: Dict of {path: content}
+            category: Category for all files
+        """
+        for path, content in files.items():
+            self.register_file(path, content, category=category)
+
+    def set_output_root(self, root: str) -> None:
+        """Set the output root directory name"""
+        self.metadata.output.root = root
+
+    def _calculate_output_summary(self) -> None:
+        """Calculate output summary statistics"""
+        files = self.metadata.output.files
+        total_bytes = sum(f.size_bytes for f in files.values())
+        by_category: Dict[str, int] = {}
+
+        for entry in files.values():
+            by_category[entry.category] = by_category.get(entry.category, 0) + 1
+
+        self.metadata.output.summary = OutputSummary(
+            total_files=len(files),
+            total_bytes=total_bytes,
+            by_category=by_category,
+        )
 
     # =========================================================================
     # Persistence

--- a/src/devdox_ai_locust/utils/metadata_manager.py
+++ b/src/devdox_ai_locust/utils/metadata_manager.py
@@ -1,0 +1,419 @@
+"""
+Central Metadata Manager for DevDox AI Locust
+
+Manages the .devdox_ai_locust/ directory and central metadata.json file.
+This is the single source of truth for all generated test information and
+is extensible for features like patch tracking, test history, and more.
+
+Structure:
+    .devdox_ai_locust/
+    ├── metadata.json           # Central metadata file
+    └── patches/                # Patch tracking subdirectory
+        └── 2025-12-28_21-47-06/
+            ├── pre_llm.patch
+            ├── post_llm.patch
+            └── session.json
+"""
+
+import json
+import logging
+from pathlib import Path
+from datetime import datetime, timezone
+from typing import Dict, Any, Optional, List, Protocol
+from dataclasses import dataclass, asdict, field
+
+logger = logging.getLogger(__name__)
+
+METADATA_VERSION = "1.0"
+METADATA_FILENAME = "metadata.json"
+DEVDOX_DIR_NAME = ".devdox_ai_locust"
+
+
+@dataclass
+class APIMetadata:
+    """Metadata about the API being tested"""
+    title: str = "Unknown"
+    version: str = "Unknown"
+    base_url: str = ""
+    description: str = ""
+    endpoints_count: int = 0
+    swagger_source: str = ""
+    source_type: str = ""  # "url" or "file"
+
+
+@dataclass
+class GenerationMetadata:
+    """Metadata about the generation session"""
+    session_id: str = ""
+    created_at: str = ""
+    host: str = ""
+    auth_enabled: bool = True
+    db_type: str = ""
+    custom_requirement: str = ""
+    processing_time_seconds: float = 0.0
+    ai_model: str = ""
+    enhancements_applied: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+
+@dataclass
+class OutputMetadata:
+    """Metadata about generated output files"""
+    directory: str = ""
+    main_files: List[str] = field(default_factory=list)
+    workflow_files: List[str] = field(default_factory=list)
+    total_files: int = 0
+
+
+@dataclass
+class PatchFeatureMetadata:
+    """Metadata for the patch tracking feature"""
+    enabled: bool = True
+    sessions: List[str] = field(default_factory=list)
+    latest_session: str = ""
+
+
+@dataclass
+class FeaturesMetadata:
+    """Container for all extensible features"""
+    patches: PatchFeatureMetadata = field(default_factory=PatchFeatureMetadata)
+    # Future features can be added here:
+    # test_history: TestHistoryMetadata = field(default_factory=TestHistoryMetadata)
+    # analytics: AnalyticsMetadata = field(default_factory=AnalyticsMetadata)
+
+
+@dataclass
+class CentralMetadata:
+    """
+    Central metadata structure for DevDox AI Locust.
+
+    This is the main data structure stored in .devdox_ai_locust/metadata.json.
+    It's designed to be extensible - new features can add their own sections
+    under the `features` field.
+    """
+    version: str = METADATA_VERSION
+    created_at: str = ""
+    updated_at: str = ""
+    api: APIMetadata = field(default_factory=APIMetadata)
+    generation: GenerationMetadata = field(default_factory=GenerationMetadata)
+    output: OutputMetadata = field(default_factory=OutputMetadata)
+    features: FeaturesMetadata = field(default_factory=FeaturesMetadata)
+
+
+class MetadataStorageProtocol(Protocol):
+    """Protocol for metadata storage backends (allows dependency injection)"""
+
+    def load(self) -> Optional[CentralMetadata]:
+        """Load metadata from storage"""
+        ...
+
+    def save(self, metadata: CentralMetadata) -> Path:
+        """Save metadata to storage"""
+        ...
+
+    def exists(self) -> bool:
+        """Check if metadata exists"""
+        ...
+
+    def get_devdox_dir(self) -> Path:
+        """Get the .devdox_ai_locust directory path"""
+        ...
+
+
+class FileSystemMetadataStorage:
+    """File system based metadata storage"""
+
+    def __init__(self, output_dir: Path):
+        self.output_dir = Path(output_dir)
+        self.devdox_dir = self.output_dir / DEVDOX_DIR_NAME
+        self.metadata_path = self.devdox_dir / METADATA_FILENAME
+
+    def _ensure_dir(self) -> Path:
+        """Ensure .devdox_ai_locust directory exists"""
+        self.devdox_dir.mkdir(parents=True, exist_ok=True)
+        return self.devdox_dir
+
+    def get_devdox_dir(self) -> Path:
+        """Get the .devdox_ai_locust directory path"""
+        return self._ensure_dir()
+
+    def exists(self) -> bool:
+        """Check if metadata file exists"""
+        return self.metadata_path.exists()
+
+    def load(self) -> Optional[CentralMetadata]:
+        """Load metadata from file"""
+        if not self.exists():
+            return None
+
+        try:
+            with open(self.metadata_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+
+            # Reconstruct the dataclass structure
+            return self._dict_to_metadata(data)
+        except Exception as e:
+            logger.warning(f"Failed to load metadata: {e}")
+            return None
+
+    def save(self, metadata: CentralMetadata) -> Path:
+        """Save metadata to file"""
+        self._ensure_dir()
+
+        # Update the updated_at timestamp
+        metadata.updated_at = datetime.now(timezone.utc).isoformat()
+
+        # Convert to dict and save
+        data = self._metadata_to_dict(metadata)
+
+        with open(self.metadata_path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2, default=str)
+
+        logger.debug(f"Saved metadata to: {self.metadata_path}")
+        return self.metadata_path
+
+    def _metadata_to_dict(self, metadata: CentralMetadata) -> Dict[str, Any]:
+        """Convert CentralMetadata to dictionary"""
+        return asdict(metadata)
+
+    def _dict_to_metadata(self, data: Dict[str, Any]) -> CentralMetadata:
+        """Convert dictionary to CentralMetadata"""
+        # Handle nested dataclasses
+        api_data = data.get('api', {})
+        api = APIMetadata(**api_data) if api_data else APIMetadata()
+
+        gen_data = data.get('generation', {})
+        generation = GenerationMetadata(**gen_data) if gen_data else GenerationMetadata()
+
+        output_data = data.get('output', {})
+        output = OutputMetadata(**output_data) if output_data else OutputMetadata()
+
+        features_data = data.get('features', {})
+        patches_data = features_data.get('patches', {})
+        patches = PatchFeatureMetadata(**patches_data) if patches_data else PatchFeatureMetadata()
+        features = FeaturesMetadata(patches=patches)
+
+        return CentralMetadata(
+            version=data.get('version', METADATA_VERSION),
+            created_at=data.get('created_at', ''),
+            updated_at=data.get('updated_at', ''),
+            api=api,
+            generation=generation,
+            output=output,
+            features=features
+        )
+
+
+class MetadataManager:
+    """
+    Central manager for .devdox_ai_locust/ metadata.
+
+    This is the main interface for the generate command and other features
+    to interact with the metadata system.
+
+    Usage:
+        manager = MetadataManager(output_dir)
+        manager.initialize_session(api_info, swagger_source)
+
+        # During generation
+        manager.update_generation_info(host=host, auth=auth)
+
+        # After generation
+        manager.register_files(main_files, workflow_files)
+        manager.finalize_session(processing_time, ai_model, enhancements)
+    """
+
+    def __init__(
+        self,
+        output_dir: Path,
+        storage: Optional[MetadataStorageProtocol] = None
+    ):
+        self.output_dir = Path(output_dir)
+        self.storage = storage or FileSystemMetadataStorage(self.output_dir)
+        self._metadata: Optional[CentralMetadata] = None
+        self._session_start_time: Optional[datetime] = None
+
+    @property
+    def metadata(self) -> CentralMetadata:
+        """Get current metadata, loading from storage if needed"""
+        if self._metadata is None:
+            self._metadata = self.storage.load() or CentralMetadata()
+        return self._metadata
+
+    @property
+    def devdox_dir(self) -> Path:
+        """Get the .devdox_ai_locust directory path"""
+        return self.storage.get_devdox_dir()
+
+    @property
+    def patches_dir(self) -> Path:
+        """Get the patches subdirectory path"""
+        patches_path = self.devdox_dir / "patches"
+        patches_path.mkdir(parents=True, exist_ok=True)
+        return patches_path
+
+    def generate_session_id(self) -> str:
+        """Generate a timestamped session ID"""
+        return datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+    def initialize_session(
+        self,
+        api_info: Optional[Dict[str, Any]] = None,
+        swagger_source: str = "",
+        source_type: str = ""
+    ) -> str:
+        """
+        Initialize a new generation session.
+
+        Args:
+            api_info: API information from OpenAPI parser
+            swagger_source: URL or file path of the swagger source
+            source_type: "url" or "file"
+
+        Returns:
+            Session ID
+        """
+        session_id = self.generate_session_id()
+        self._session_start_time = datetime.now(timezone.utc)
+
+        # Load existing metadata or create new
+        self._metadata = self.storage.load() or CentralMetadata()
+
+        # Set creation timestamp if new
+        if not self._metadata.created_at:
+            self._metadata.created_at = self._session_start_time.isoformat()
+
+        # Update API metadata
+        if api_info:
+            self._metadata.api = APIMetadata(
+                title=api_info.get('title', 'Unknown'),
+                version=api_info.get('version', 'Unknown'),
+                base_url=api_info.get('base_url', ''),
+                description=api_info.get('description', ''),
+                endpoints_count=api_info.get('endpoints_count', 0),
+                swagger_source=swagger_source,
+                source_type=source_type
+            )
+
+        # Initialize generation metadata
+        self._metadata.generation = GenerationMetadata(
+            session_id=session_id,
+            created_at=self._session_start_time.isoformat()
+        )
+
+        # Set output directory
+        self._metadata.output.directory = str(self.output_dir.absolute())
+
+        logger.info(f"Initialized metadata session: {session_id}")
+        return session_id
+
+    def update_generation_config(
+        self,
+        host: Optional[str] = None,
+        auth_enabled: Optional[bool] = None,
+        db_type: Optional[str] = None,
+        custom_requirement: Optional[str] = None,
+        ai_model: Optional[str] = None
+    ) -> None:
+        """Update generation configuration in metadata"""
+        gen = self.metadata.generation
+
+        if host is not None:
+            gen.host = host
+        if auth_enabled is not None:
+            gen.auth_enabled = auth_enabled
+        if db_type is not None:
+            gen.db_type = db_type
+        if custom_requirement is not None:
+            gen.custom_requirement = custom_requirement
+        if ai_model is not None:
+            gen.ai_model = ai_model
+
+    def update_api_endpoints_count(self, count: int) -> None:
+        """Update the endpoints count"""
+        self.metadata.api.endpoints_count = count
+
+    def register_files(
+        self,
+        main_files: Optional[List[str]] = None,
+        workflow_files: Optional[List[str]] = None
+    ) -> None:
+        """Register generated files in metadata"""
+        output = self.metadata.output
+
+        if main_files:
+            output.main_files = main_files
+        if workflow_files:
+            output.workflow_files = workflow_files
+
+        output.total_files = len(output.main_files) + len(output.workflow_files)
+
+    def register_patch_session(self, patch_session_id: str) -> None:
+        """Register a patch tracking session"""
+        patches = self.metadata.features.patches
+        patches.enabled = True
+
+        if patch_session_id not in patches.sessions:
+            patches.sessions.append(patch_session_id)
+
+        patches.latest_session = patch_session_id
+
+    def add_enhancement(self, enhancement: str) -> None:
+        """Add an enhancement to the list"""
+        if enhancement not in self.metadata.generation.enhancements_applied:
+            self.metadata.generation.enhancements_applied.append(enhancement)
+
+    def add_error(self, error: str) -> None:
+        """Add an error to the list"""
+        self.metadata.generation.errors.append(error)
+
+    def finalize_session(
+        self,
+        enhancements_applied: Optional[List[str]] = None,
+        errors: Optional[List[str]] = None
+    ) -> CentralMetadata:
+        """
+        Finalize the session and save metadata.
+
+        Args:
+            enhancements_applied: List of enhancements that were applied
+            errors: List of errors that occurred
+
+        Returns:
+            The finalized CentralMetadata
+        """
+        # Calculate processing time
+        if self._session_start_time:
+            processing_time = (
+                datetime.now(timezone.utc) - self._session_start_time
+            ).total_seconds()
+            self.metadata.generation.processing_time_seconds = processing_time
+
+        # Update enhancements and errors
+        if enhancements_applied:
+            self.metadata.generation.enhancements_applied = enhancements_applied
+        if errors:
+            self.metadata.generation.errors = errors
+
+        # Save to storage
+        self.storage.save(self.metadata)
+
+        logger.info(f"Finalized metadata session: {self.metadata.generation.session_id}")
+        return self.metadata
+
+    def get_file_paths(self) -> Dict[str, List[Path]]:
+        """Get full paths to all registered files"""
+        output_dir = Path(self.metadata.output.directory)
+
+        return {
+            'main_files': [
+                output_dir / f for f in self.metadata.output.main_files
+            ],
+            'workflow_files': [
+                output_dir / f for f in self.metadata.output.workflow_files
+            ]
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Export metadata as dictionary"""
+        return asdict(self.metadata)

--- a/src/devdox_ai_locust/utils/metadata_manager.py
+++ b/src/devdox_ai_locust/utils/metadata_manager.py
@@ -1,32 +1,64 @@
 """
 Central Metadata Manager for DevDox AI Locust
 
-Manages the .devdox_ai_locust/ directory and central metadata.json file.
-This is the single source of truth for all generated test information and
-is extensible for features like patch tracking, test history, and more.
+Manages the .devdox_ai_locust/ directory with a clear, organized structure.
+This is the single source of truth for all generated test information.
 
-Structure:
+Directory Structure:
     .devdox_ai_locust/
-    ├── metadata.json           # Central metadata file
-    └── patches/                # Patch tracking subdirectory
-        └── 2025-12-28_21-47-06/
-            ├── pre_llm.patch
-            ├── post_llm.patch
-            └── session.json
+    ├── metadata.json                    # Central metadata file (main index)
+    │
+    ├── generation/                      # Generation-related data
+    │   └── sessions/                    # Historical session data
+    │       └── {session_id}/
+    │           └── config.json          # Session-specific config
+    │
+    ├── ai_enhancement/                  # AI enhancement tracking
+    │   ├── patches/                     # Pre/post LLM code patches
+    │   │   └── {session_id}/
+    │   │       ├── pre_llm.patch        # Code before AI enhancement
+    │   │       ├── post_llm.patch       # Code after AI enhancement
+    │   │       └── summary.json         # Patch statistics
+    │   │
+    │   └── constraints/                 # AI sandbox constraints used
+    │       └── {session_id}/
+    │           ├── test_data.txt        # Constraints for test_data.py
+    │           └── utils.txt            # Constraints for utils.py
+    │
+    ├── codebase_analysis/               # CodebaseAwareness outputs
+    │   └── {session_id}/
+    │       ├── dependencies.json        # File dependency map
+    │       ├── protected_symbols.json   # Protected symbols per file
+    │       └── exports.json             # Exports per file
+    │
+    └── logs/                            # Generation logs
+        └── {session_id}.log
 """
 
 import json
 import logging
 from pathlib import Path
 from datetime import datetime, timezone
-from typing import Dict, Any, Optional, List, Protocol
+from typing import Dict, Any, Optional, List, Protocol, Set
 from dataclasses import dataclass, asdict, field
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
-METADATA_VERSION = "1.0"
+METADATA_VERSION = "2.0"
 METADATA_FILENAME = "metadata.json"
 DEVDOX_DIR_NAME = ".devdox_ai_locust"
+
+
+class SubDirectory(str, Enum):
+    """Subdirectories within .devdox_ai_locust/"""
+    GENERATION = "generation"
+    GENERATION_SESSIONS = "generation/sessions"
+    AI_ENHANCEMENT = "ai_enhancement"
+    AI_PATCHES = "ai_enhancement/patches"
+    AI_CONSTRAINTS = "ai_enhancement/constraints"
+    CODEBASE_ANALYSIS = "codebase_analysis"
+    LOGS = "logs"
 
 
 @dataclass
@@ -66,20 +98,39 @@ class OutputMetadata:
 
 
 @dataclass
-class PatchFeatureMetadata:
-    """Metadata for the patch tracking feature"""
+class PatchSessionInfo:
+    """Information about a patch session"""
+    session_id: str
+    created_at: str
+    pre_llm_files: int = 0
+    post_llm_files: int = 0
+    files_changed: int = 0
+    files_added: int = 0
+    files_removed: int = 0
+
+
+@dataclass
+class AIEnhancementMetadata:
+    """Metadata for AI enhancement feature"""
     enabled: bool = True
-    sessions: List[str] = field(default_factory=list)
+    total_sessions: int = 0
     latest_session: str = ""
+    sessions: List[str] = field(default_factory=list)
+
+
+@dataclass
+class CodebaseAnalysisMetadata:
+    """Metadata for codebase analysis feature"""
+    enabled: bool = True
+    latest_session: str = ""
+    total_protected_symbols: int = 0
 
 
 @dataclass
 class FeaturesMetadata:
     """Container for all extensible features"""
-    patches: PatchFeatureMetadata = field(default_factory=PatchFeatureMetadata)
-    # Future features can be added here:
-    # test_history: TestHistoryMetadata = field(default_factory=TestHistoryMetadata)
-    # analytics: AnalyticsMetadata = field(default_factory=AnalyticsMetadata)
+    ai_enhancement: AIEnhancementMetadata = field(default_factory=AIEnhancementMetadata)
+    codebase_analysis: CodebaseAnalysisMetadata = field(default_factory=CodebaseAnalysisMetadata)
 
 
 @dataclass
@@ -88,8 +139,7 @@ class CentralMetadata:
     Central metadata structure for DevDox AI Locust.
 
     This is the main data structure stored in .devdox_ai_locust/metadata.json.
-    It's designed to be extensible - new features can add their own sections
-    under the `features` field.
+    It provides a high-level overview; detailed data is in subdirectories.
     """
     version: str = METADATA_VERSION
     created_at: str = ""
@@ -189,9 +239,19 @@ class FileSystemMetadataStorage:
         output = OutputMetadata(**output_data) if output_data else OutputMetadata()
 
         features_data = data.get('features', {})
-        patches_data = features_data.get('patches', {})
-        patches = PatchFeatureMetadata(**patches_data) if patches_data else PatchFeatureMetadata()
-        features = FeaturesMetadata(patches=patches)
+
+        # Handle AI enhancement metadata
+        ai_data = features_data.get('ai_enhancement', {})
+        ai_enhancement = AIEnhancementMetadata(**ai_data) if ai_data else AIEnhancementMetadata()
+
+        # Handle codebase analysis metadata
+        codebase_data = features_data.get('codebase_analysis', {})
+        codebase_analysis = CodebaseAnalysisMetadata(**codebase_data) if codebase_data else CodebaseAnalysisMetadata()
+
+        features = FeaturesMetadata(
+            ai_enhancement=ai_enhancement,
+            codebase_analysis=codebase_analysis
+        )
 
         return CentralMetadata(
             version=data.get('version', METADATA_VERSION),
@@ -232,6 +292,7 @@ class MetadataManager:
         self.storage = storage or FileSystemMetadataStorage(self.output_dir)
         self._metadata: Optional[CentralMetadata] = None
         self._session_start_time: Optional[datetime] = None
+        self._current_session_id: Optional[str] = None
 
     @property
     def metadata(self) -> CentralMetadata:
@@ -246,11 +307,60 @@ class MetadataManager:
         return self.storage.get_devdox_dir()
 
     @property
+    def session_id(self) -> str:
+        """Get the current session ID"""
+        return self._current_session_id or self.generate_session_id()
+
+    # =========================================================================
+    # Directory Access Methods
+    # =========================================================================
+
+    def get_subdir(self, subdir: SubDirectory, session_id: Optional[str] = None) -> Path:
+        """
+        Get a subdirectory path within .devdox_ai_locust/
+
+        Args:
+            subdir: The subdirectory type
+            session_id: Optional session ID for session-specific subdirs
+
+        Returns:
+            Path to the subdirectory (created if needed)
+        """
+        path = self.devdox_dir / subdir.value
+        if session_id:
+            path = path / session_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def get_patches_dir(self, session_id: Optional[str] = None) -> Path:
+        """Get the AI patches directory for a session"""
+        return self.get_subdir(SubDirectory.AI_PATCHES, session_id or self.session_id)
+
+    def get_constraints_dir(self, session_id: Optional[str] = None) -> Path:
+        """Get the AI constraints directory for a session"""
+        return self.get_subdir(SubDirectory.AI_CONSTRAINTS, session_id or self.session_id)
+
+    def get_codebase_analysis_dir(self, session_id: Optional[str] = None) -> Path:
+        """Get the codebase analysis directory for a session"""
+        return self.get_subdir(SubDirectory.CODEBASE_ANALYSIS, session_id or self.session_id)
+
+    def get_generation_session_dir(self, session_id: Optional[str] = None) -> Path:
+        """Get the generation session directory"""
+        return self.get_subdir(SubDirectory.GENERATION_SESSIONS, session_id or self.session_id)
+
+    def get_logs_dir(self) -> Path:
+        """Get the logs directory"""
+        return self.get_subdir(SubDirectory.LOGS)
+
+    # Backwards compatibility
+    @property
     def patches_dir(self) -> Path:
-        """Get the patches subdirectory path"""
-        patches_path = self.devdox_dir / "patches"
-        patches_path.mkdir(parents=True, exist_ok=True)
-        return patches_path
+        """Get the patches subdirectory path (backwards compatible)"""
+        return self.get_patches_dir()
+
+    # =========================================================================
+    # Session Management
+    # =========================================================================
 
     def generate_session_id(self) -> str:
         """Generate a timestamped session ID"""
@@ -273,7 +383,7 @@ class MetadataManager:
         Returns:
             Session ID
         """
-        session_id = self.generate_session_id()
+        self._current_session_id = self.generate_session_id()
         self._session_start_time = datetime.now(timezone.utc)
 
         # Load existing metadata or create new
@@ -297,15 +407,15 @@ class MetadataManager:
 
         # Initialize generation metadata
         self._metadata.generation = GenerationMetadata(
-            session_id=session_id,
+            session_id=self._current_session_id,
             created_at=self._session_start_time.isoformat()
         )
 
         # Set output directory
         self._metadata.output.directory = str(self.output_dir.absolute())
 
-        logger.info(f"Initialized metadata session: {session_id}")
-        return session_id
+        logger.info(f"Initialized metadata session: {self._current_session_id}")
+        return self._current_session_id
 
     def update_generation_config(
         self,
@@ -348,15 +458,180 @@ class MetadataManager:
 
         output.total_files = len(output.main_files) + len(output.workflow_files)
 
+    # =========================================================================
+    # AI Enhancement Tracking
+    # =========================================================================
+
+    def save_patch_summary(
+        self,
+        pre_llm_files: int,
+        post_llm_files: int,
+        files_changed: int,
+        files_added: int = 0,
+        files_removed: int = 0,
+        patches: Optional[Dict[str, str]] = None
+    ) -> Path:
+        """
+        Save patch summary to the patches directory.
+
+        Args:
+            pre_llm_files: Number of files before LLM
+            post_llm_files: Number of files after LLM
+            files_changed: Number of files changed
+            files_added: Number of files added
+            files_removed: Number of files removed
+            patches: Dict of filename -> unified diff
+
+        Returns:
+            Path to the summary file
+        """
+        patches_dir = self.get_patches_dir()
+
+        summary = {
+            "session_id": self.session_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "pre_llm_files_count": pre_llm_files,
+            "post_llm_files_count": post_llm_files,
+            "files_changed": files_changed,
+            "files_added": files_added,
+            "files_removed": files_removed,
+        }
+
+        # Save summary
+        summary_path = patches_dir / "summary.json"
+        with open(summary_path, 'w', encoding='utf-8') as f:
+            json.dump(summary, f, indent=2)
+
+        # Save patches if provided
+        if patches:
+            patches_file = patches_dir / "patches.json"
+            with open(patches_file, 'w', encoding='utf-8') as f:
+                json.dump(patches, f, indent=2)
+
+        # Update metadata
+        ai_meta = self.metadata.features.ai_enhancement
+        ai_meta.enabled = True
+        ai_meta.total_sessions += 1
+        ai_meta.latest_session = self.session_id
+        if self.session_id not in ai_meta.sessions:
+            ai_meta.sessions.append(self.session_id)
+
+        logger.info(f"Saved patch summary to: {patches_dir}")
+        return summary_path
+
+    def save_constraints(
+        self,
+        filename: str,
+        constraints: str
+    ) -> Path:
+        """
+        Save AI constraints used for a file.
+
+        Args:
+            filename: The file the constraints were for (e.g., "test_data.py")
+            constraints: The constraint text sent to AI
+
+        Returns:
+            Path to the saved constraints file
+        """
+        constraints_dir = self.get_constraints_dir()
+
+        # Clean filename for saving
+        clean_name = filename.replace('.py', '').replace('/', '_')
+        constraints_path = constraints_dir / f"{clean_name}.constraints.txt"
+
+        with open(constraints_path, 'w', encoding='utf-8') as f:
+            f.write(f"# Constraints for {filename}\n")
+            f.write(f"# Session: {self.session_id}\n")
+            f.write(f"# Generated: {datetime.now(timezone.utc).isoformat()}\n")
+            f.write("\n")
+            f.write(constraints)
+
+        logger.debug(f"Saved constraints for {filename} to: {constraints_path}")
+        return constraints_path
+
+    # =========================================================================
+    # Codebase Analysis Storage
+    # =========================================================================
+
+    def save_codebase_analysis(
+        self,
+        exports: Dict[str, List[str]],
+        imports: Dict[str, Dict[str, List[str]]],
+        protected_symbols: Dict[str, List[Dict[str, Any]]]
+    ) -> Path:
+        """
+        Save codebase analysis results.
+
+        Args:
+            exports: Dict of filename -> list of exported symbols
+            imports: Dict of filename -> {source_file: imported_symbols}
+            protected_symbols: Dict of filename -> list of protected symbol info
+
+        Returns:
+            Path to the analysis directory
+        """
+        analysis_dir = self.get_codebase_analysis_dir()
+
+        # Save exports
+        exports_path = analysis_dir / "exports.json"
+        with open(exports_path, 'w', encoding='utf-8') as f:
+            json.dump({
+                "session_id": self.session_id,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "files": {k: list(v) if isinstance(v, set) else v for k, v in exports.items()}
+            }, f, indent=2)
+
+        # Save dependencies (imports)
+        deps_path = analysis_dir / "dependencies.json"
+        with open(deps_path, 'w', encoding='utf-8') as f:
+            json.dump({
+                "session_id": self.session_id,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "imports": {
+                    k: {sk: list(sv) if isinstance(sv, set) else sv for sk, sv in v.items()}
+                    for k, v in imports.items()
+                }
+            }, f, indent=2)
+
+        # Save protected symbols
+        protected_path = analysis_dir / "protected_symbols.json"
+        total_protected = sum(len(v) for v in protected_symbols.values())
+        with open(protected_path, 'w', encoding='utf-8') as f:
+            json.dump({
+                "session_id": self.session_id,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "total_protected_symbols": total_protected,
+                "by_file": protected_symbols
+            }, f, indent=2)
+
+        # Update metadata
+        codebase_meta = self.metadata.features.codebase_analysis
+        codebase_meta.enabled = True
+        codebase_meta.latest_session = self.session_id
+        codebase_meta.total_protected_symbols = total_protected
+
+        logger.info(f"Saved codebase analysis to: {analysis_dir}")
+        return analysis_dir
+
+    # =========================================================================
+    # Backwards Compatibility
+    # =========================================================================
+
     def register_patch_session(self, patch_session_id: str) -> None:
-        """Register a patch tracking session"""
-        patches = self.metadata.features.patches
-        patches.enabled = True
+        """Register a patch tracking session (backwards compatible)"""
+        ai_meta = self.metadata.features.ai_enhancement
+        ai_meta.enabled = True
 
-        if patch_session_id not in patches.sessions:
-            patches.sessions.append(patch_session_id)
+        if patch_session_id not in ai_meta.sessions:
+            ai_meta.sessions.append(patch_session_id)
 
-        patches.latest_session = patch_session_id
+        ai_meta.latest_session = patch_session_id
+        ai_meta.total_sessions = len(ai_meta.sessions)
+
+    # =========================================================================
+    # Enhancement and Error Tracking
+    # =========================================================================
 
     def add_enhancement(self, enhancement: str) -> None:
         """Add an enhancement to the list"""
@@ -366,6 +641,10 @@ class MetadataManager:
     def add_error(self, error: str) -> None:
         """Add an error to the list"""
         self.metadata.generation.errors.append(error)
+
+    # =========================================================================
+    # Session Finalization
+    # =========================================================================
 
     def finalize_session(
         self,
@@ -417,3 +696,21 @@ class MetadataManager:
     def to_dict(self) -> Dict[str, Any]:
         """Export metadata as dictionary"""
         return asdict(self.metadata)
+
+    # =========================================================================
+    # Directory Structure Info
+    # =========================================================================
+
+    def get_structure_info(self) -> str:
+        """Get a formatted string showing the directory structure"""
+        return f"""
+.devdox_ai_locust/
+├── metadata.json                         # Central metadata
+├── generation/
+│   └── sessions/{self.session_id}/       # Current session
+├── ai_enhancement/
+│   ├── patches/{self.session_id}/        # Code patches (pre/post LLM)
+│   └── constraints/{self.session_id}/    # AI sandbox constraints
+├── codebase_analysis/{self.session_id}/  # Dependency analysis
+└── logs/                                 # Generation logs
+"""

--- a/src/devdox_ai_locust/utils/open_ai_parser.py
+++ b/src/devdox_ai_locust/utils/open_ai_parser.py
@@ -9,7 +9,7 @@ import json
 import yaml
 import logging
 from typing import Dict, List, Optional, Any, Union
-from dataclasses import dataclass
+from pydantic import BaseModel, Field
 from enum import Enum
 
 logger = logging.getLogger(__name__)
@@ -18,17 +18,15 @@ application_json_type = "application/json"
 localhost_url = "http://localhost"
 
 
-class ParameterType(Enum):
+class ParameterType(str, Enum):
     QUERY = "query"
     PATH = "path"
     HEADER = "header"
     COOKIE = "cookie"
 
 
-@dataclass
-class Parameter:
+class Parameter(BaseModel):
     """Represents an OpenAPI parameter"""
-
     name: str
     location: ParameterType
     required: bool
@@ -40,41 +38,51 @@ class Parameter:
     format: Optional[str] = None
 
 
-@dataclass
-class RequestBody:
+class RequestBody(BaseModel):
     """Represents an OpenAPI request body"""
-
     content_type: str
-    schema: Dict[str, Any]
+    schema_: Dict[str, Any] = Field(alias="schema")
     required: bool = True
     description: Optional[str] = None
     examples: Optional[Dict[str, Any]] = None
 
+    class Config:
+        populate_by_name = True
 
-@dataclass
-class Response:
+    @property
+    def schema(self) -> Dict[str, Any]:
+        """Backwards compatible access to schema"""
+        return self.schema_
+
+
+class Response(BaseModel):
     """Represents an OpenAPI response"""
-
     status_code: str
     description: str
     content_type: Optional[str] = None
-    schema: Optional[Dict[str, Any]] = None
+    schema_: Optional[Dict[str, Any]] = Field(default=None, alias="schema")
     headers: Optional[Dict[str, Any]] = None
 
+    class Config:
+        populate_by_name = True
 
-@dataclass
-class Endpoint:
+    @property
+    def schema(self) -> Optional[Dict[str, Any]]:
+        """Backwards compatible access to schema"""
+        return self.schema_
+
+
+class Endpoint(BaseModel):
     """Represents a parsed API endpoint"""
-
     path: str
     method: str
-    operation_id: Optional[str]
-    summary: Optional[str]
-    description: Optional[str]
-    parameters: List[Parameter]
-    request_body: Optional[RequestBody]
-    responses: List[Response]
-    tags: List[str]
+    operation_id: Optional[str] = None
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    parameters: List[Parameter] = Field(default_factory=list)
+    request_body: Optional[RequestBody] = None
+    responses: List[Response] = Field(default_factory=list)
+    tags: List[str] = Field(default_factory=list)
     security: Optional[List[Dict[str, Any]]] = None
 
 

--- a/src/devdox_ai_locust/utils/patch_tracker.py
+++ b/src/devdox_ai_locust/utils/patch_tracker.py
@@ -26,7 +26,7 @@ import difflib
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Any, Optional, List, Protocol, TYPE_CHECKING
-from dataclasses import dataclass, asdict, field
+from pydantic import BaseModel, Field
 import asyncio
 
 if TYPE_CHECKING:
@@ -35,17 +35,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class PatchSessionMetadata:
+class PatchSessionMetadata(BaseModel):
     """Metadata for a single patch session (stored in session.json)"""
     session_id: str
     timestamp: str
     api_title: str
     api_version: str
     endpoints_count: int
-    files_generated: List[str] = field(default_factory=list)
+    files_generated: List[str] = Field(default_factory=list)
     ai_model: Optional[str] = None
-    enhancements_applied: List[str] = field(default_factory=list)
+    enhancements_applied: List[str] = Field(default_factory=list)
     generation_time_seconds: float = 0.0
     pre_llm_files_count: int = 0
     post_llm_files_count: int = 0
@@ -103,7 +102,7 @@ class FileSystemPatchStorage:
         session_dir = self.get_session_dir(session_id)
         session_file = session_dir / "session.json"
         session_file.write_text(
-            json.dumps(asdict(metadata), indent=2, default=str),
+            json.dumps(metadata.model_dump(), indent=2, default=str),
             encoding="utf-8"
         )
         logger.debug(f"Saved session metadata: {session_file}")

--- a/src/devdox_ai_locust/utils/patch_tracker.py
+++ b/src/devdox_ai_locust/utils/patch_tracker.py
@@ -6,16 +6,18 @@ Similar to PostgreSQL's WAL (Write-Ahead Logging) concept - creates timestamped
 directories with pre/post LLM patches for analysis and comparison.
 
 This module integrates with the central MetadataManager to store patch sessions
-under the .devdox_ai_locust/patches/ directory.
+under the organized .devdox_ai_locust/ directory structure.
 
-Structure:
+Structure (v2.0):
     .devdox_ai_locust/
-    ├── metadata.json              # Central metadata (managed by MetadataManager)
-    └── patches/
-        └── 2025-12-28_21-47-06/
-            ├── pre_llm.patch      # Template output before AI enhancement
-            ├── post_llm.patch     # Changes made by AI enhancement
-            └── session.json       # Session-specific metadata
+    ├── metadata.json                          # Central metadata (MetadataManager)
+    └── ai_enhancement/
+        └── patches/
+            └── {session_id}/                  # e.g., 2025-12-28_21-47-06
+                ├── pre_llm.patch              # Template output before AI
+                ├── post_llm.patch             # Changes made by AI
+                ├── summary.json               # Patch statistics
+                └── session.json               # Session-specific metadata
 """
 
 import json

--- a/src/devdox_ai_locust/utils/patch_tracker.py
+++ b/src/devdox_ai_locust/utils/patch_tracker.py
@@ -5,13 +5,17 @@ Tracks code generation by saving patch files before and after AI LLM operations.
 Similar to PostgreSQL's WAL (Write-Ahead Logging) concept - creates timestamped
 directories with pre/post LLM patches for analysis and comparison.
 
+This module integrates with the central MetadataManager to store patch sessions
+under the .devdox_ai_locust/patches/ directory.
+
 Structure:
     .devdox_ai_locust/
+    ├── metadata.json              # Central metadata (managed by MetadataManager)
     └── patches/
         └── 2025-12-28_21-47-06/
-            ├── pre_llm.patch
-            ├── post_llm.patch
-            └── metadata.json
+            ├── pre_llm.patch      # Template output before AI enhancement
+            ├── post_llm.patch     # Changes made by AI enhancement
+            └── session.json       # Session-specific metadata
 """
 
 import json
@@ -19,16 +23,20 @@ import logging
 import difflib
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Any, Optional, List, Protocol
+from typing import Dict, Any, Optional, List, Protocol, TYPE_CHECKING
 from dataclasses import dataclass, asdict, field
 import asyncio
+
+if TYPE_CHECKING:
+    from .metadata_manager import MetadataManager
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
-class PatchMetadata:
-    """Metadata for a patch session"""
+class PatchSessionMetadata:
+    """Metadata for a single patch session (stored in session.json)"""
+    session_id: str
     timestamp: str
     api_title: str
     api_version: str
@@ -37,6 +45,9 @@ class PatchMetadata:
     ai_model: Optional[str] = None
     enhancements_applied: List[str] = field(default_factory=list)
     generation_time_seconds: float = 0.0
+    pre_llm_files_count: int = 0
+    post_llm_files_count: int = 0
+    files_changed: int = 0
     error: Optional[str] = None
 
 
@@ -47,8 +58,8 @@ class PatchStorageProtocol(Protocol):
         """Save a patch file"""
         ...
 
-    def save_metadata(self, session_id: str, metadata: PatchMetadata) -> Path:
-        """Save metadata file"""
+    def save_session_metadata(self, session_id: str, metadata: PatchSessionMetadata) -> Path:
+        """Save session metadata file"""
         ...
 
     def get_session_dir(self, session_id: str) -> Path:
@@ -59,8 +70,14 @@ class PatchStorageProtocol(Protocol):
 class FileSystemPatchStorage:
     """File system based patch storage"""
 
-    def __init__(self, base_dir: Path):
-        self.base_dir = base_dir / ".devdox_ai_locust" / "patches"
+    def __init__(self, patches_dir: Path):
+        """
+        Initialize patch storage.
+
+        Args:
+            patches_dir: The patches directory (typically .devdox_ai_locust/patches/)
+        """
+        self.patches_dir = Path(patches_dir)
 
     def _ensure_dir(self, path: Path) -> Path:
         """Ensure directory exists"""
@@ -69,7 +86,7 @@ class FileSystemPatchStorage:
 
     def get_session_dir(self, session_id: str) -> Path:
         """Get the session directory path"""
-        return self._ensure_dir(self.base_dir / session_id)
+        return self._ensure_dir(self.patches_dir / session_id)
 
     def save_patch(self, session_id: str, patch_name: str, content: str) -> Path:
         """Save a patch file"""
@@ -79,24 +96,33 @@ class FileSystemPatchStorage:
         logger.debug(f"Saved patch: {patch_file}")
         return patch_file
 
-    def save_metadata(self, session_id: str, metadata: PatchMetadata) -> Path:
-        """Save metadata file"""
+    def save_session_metadata(self, session_id: str, metadata: PatchSessionMetadata) -> Path:
+        """Save session-specific metadata file (session.json)"""
         session_dir = self.get_session_dir(session_id)
-        metadata_file = session_dir / "metadata.json"
-        metadata_file.write_text(
+        session_file = session_dir / "session.json"
+        session_file.write_text(
             json.dumps(asdict(metadata), indent=2, default=str),
             encoding="utf-8"
         )
-        logger.debug(f"Saved metadata: {metadata_file}")
-        return metadata_file
+        logger.debug(f"Saved session metadata: {session_file}")
+        return session_file
 
 
 class PatchTracker:
     """
     Tracks code generation by creating unified diffs before/after AI operations.
 
+    Integrates with MetadataManager to store patches under .devdox_ai_locust/patches/
+    and register sessions with the central metadata.
+
     Usage:
+        # Standalone usage (creates its own patches directory)
         tracker = PatchTracker(output_dir)
+        tracker.start_session(api_info)
+
+        # Or integrated with MetadataManager
+        metadata_manager = MetadataManager(output_dir)
+        tracker = PatchTracker.from_metadata_manager(metadata_manager)
         tracker.start_session(api_info)
 
         # Before AI enhancement
@@ -113,14 +139,32 @@ class PatchTracker:
     def __init__(
         self,
         output_dir: Path,
-        storage: Optional[PatchStorageProtocol] = None
+        storage: Optional[PatchStorageProtocol] = None,
+        metadata_manager: Optional["MetadataManager"] = None
     ):
         self.output_dir = Path(output_dir)
-        self.storage = storage or FileSystemPatchStorage(self.output_dir)
+        self.metadata_manager = metadata_manager
+
+        # Determine patches directory
+        if metadata_manager:
+            patches_dir = metadata_manager.patches_dir
+        else:
+            patches_dir = self.output_dir / ".devdox_ai_locust" / "patches"
+            patches_dir.mkdir(parents=True, exist_ok=True)
+
+        self.storage = storage or FileSystemPatchStorage(patches_dir)
         self.session_id: Optional[str] = None
         self.pre_llm_files: Dict[str, str] = {}
         self.post_llm_files: Dict[str, str] = {}
         self._start_time: Optional[datetime] = None
+
+    @classmethod
+    def from_metadata_manager(cls, metadata_manager: "MetadataManager") -> "PatchTracker":
+        """Create a PatchTracker integrated with a MetadataManager"""
+        return cls(
+            output_dir=metadata_manager.output_dir,
+            metadata_manager=metadata_manager
+        )
 
     def _generate_session_id(self) -> str:
         """Generate PostgreSQL-style timestamped session ID"""
@@ -262,7 +306,7 @@ class PatchTracker:
         ai_model: Optional[str] = None,
         enhancements_applied: Optional[List[str]] = None,
         error: Optional[str] = None
-    ) -> PatchMetadata:
+    ) -> PatchSessionMetadata:
         """Finalize the session and save metadata"""
         if not self.session_id:
             raise RuntimeError("No active session.")
@@ -272,9 +316,13 @@ class PatchTracker:
         if self._start_time:
             generation_time = (datetime.now() - self._start_time).total_seconds()
 
-        # Build metadata
-        metadata = PatchMetadata(
-            timestamp=self.session_id,
+        # Calculate files changed
+        files_changed = self._count_changed_files()
+
+        # Build session metadata
+        metadata = PatchSessionMetadata(
+            session_id=self.session_id,
+            timestamp=datetime.now().isoformat(),
             api_title=api_info.get("title", "Unknown") if api_info else "Unknown",
             api_version=api_info.get("version", "Unknown") if api_info else "Unknown",
             endpoints_count=endpoints_count,
@@ -282,12 +330,19 @@ class PatchTracker:
             ai_model=ai_model,
             enhancements_applied=enhancements_applied or [],
             generation_time_seconds=generation_time,
+            pre_llm_files_count=len(self.pre_llm_files),
+            post_llm_files_count=len(self.post_llm_files),
+            files_changed=files_changed,
             error=error
         )
 
-        # Save patches and metadata
+        # Save patches and session metadata
         self.save_patches()
-        self.storage.save_metadata(self.session_id, metadata)
+        self.storage.save_session_metadata(self.session_id, metadata)
+
+        # Register with central metadata manager if available
+        if self.metadata_manager:
+            self.metadata_manager.register_patch_session(self.session_id)
 
         logger.info(f"Finalized patch session: {self.session_id}")
 
@@ -299,6 +354,17 @@ class PatchTracker:
         self._start_time = None
 
         return metadata
+
+    def _count_changed_files(self) -> int:
+        """Count number of files that were changed by LLM"""
+        changed = 0
+        all_files = set(self.pre_llm_files.keys()) | set(self.post_llm_files.keys())
+        for filename in all_files:
+            before = self.pre_llm_files.get(filename, "")
+            after = self.post_llm_files.get(filename, "")
+            if before != after:
+                changed += 1
+        return changed
 
     def get_session_path(self) -> Optional[Path]:
         """Get the current session's directory path"""
@@ -312,28 +378,40 @@ class PatchTrackerContext:
     Context manager for patch tracking.
 
     Usage:
+        # Standalone usage
         async with PatchTrackerContext(output_dir, api_info) as tracker:
             tracker.capture_pre_llm_state(base_files, workflow_files)
             enhanced_files = await enhance_with_ai(base_files)
             tracker.capture_post_llm_state(enhanced_files, enhanced_workflow_files)
+
+        # With MetadataManager integration
+        metadata_manager = MetadataManager(output_dir)
+        async with PatchTrackerContext(output_dir, api_info, metadata_manager=metadata_manager) as tracker:
+            ...
     """
 
     def __init__(
         self,
         output_dir: Path,
         api_info: Optional[Dict[str, Any]] = None,
-        enabled: bool = True
+        enabled: bool = True,
+        metadata_manager: Optional["MetadataManager"] = None
     ):
         self.output_dir = output_dir
         self.api_info = api_info
         self.enabled = enabled
+        self.metadata_manager = metadata_manager
         self.tracker: Optional[PatchTracker] = None
 
     async def __aenter__(self) -> Optional[PatchTracker]:
         if not self.enabled:
             return None
 
-        self.tracker = PatchTracker(self.output_dir)
+        if self.metadata_manager:
+            self.tracker = PatchTracker.from_metadata_manager(self.metadata_manager)
+        else:
+            self.tracker = PatchTracker(self.output_dir)
+
         self.tracker.start_session(self.api_info)
         return self.tracker
 

--- a/src/devdox_ai_locust/utils/patch_tracker.py
+++ b/src/devdox_ai_locust/utils/patch_tracker.py
@@ -1,0 +1,346 @@
+"""
+Patch Tracking System for DevDox AI Locust
+
+Tracks code generation by saving patch files before and after AI LLM operations.
+Similar to PostgreSQL's WAL (Write-Ahead Logging) concept - creates timestamped
+directories with pre/post LLM patches for analysis and comparison.
+
+Structure:
+    .devdox_ai_locust/
+    └── patches/
+        └── 2025-12-28_21-47-06/
+            ├── pre_llm.patch
+            ├── post_llm.patch
+            └── metadata.json
+"""
+
+import json
+import logging
+import difflib
+from pathlib import Path
+from datetime import datetime
+from typing import Dict, Any, Optional, List, Protocol
+from dataclasses import dataclass, asdict, field
+import asyncio
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PatchMetadata:
+    """Metadata for a patch session"""
+    timestamp: str
+    api_title: str
+    api_version: str
+    endpoints_count: int
+    files_generated: List[str] = field(default_factory=list)
+    ai_model: Optional[str] = None
+    enhancements_applied: List[str] = field(default_factory=list)
+    generation_time_seconds: float = 0.0
+    error: Optional[str] = None
+
+
+class PatchStorageProtocol(Protocol):
+    """Protocol for patch storage backends (allows dependency injection)"""
+
+    def save_patch(self, session_id: str, patch_name: str, content: str) -> Path:
+        """Save a patch file"""
+        ...
+
+    def save_metadata(self, session_id: str, metadata: PatchMetadata) -> Path:
+        """Save metadata file"""
+        ...
+
+    def get_session_dir(self, session_id: str) -> Path:
+        """Get the session directory path"""
+        ...
+
+
+class FileSystemPatchStorage:
+    """File system based patch storage"""
+
+    def __init__(self, base_dir: Path):
+        self.base_dir = base_dir / ".devdox_ai_locust" / "patches"
+
+    def _ensure_dir(self, path: Path) -> Path:
+        """Ensure directory exists"""
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def get_session_dir(self, session_id: str) -> Path:
+        """Get the session directory path"""
+        return self._ensure_dir(self.base_dir / session_id)
+
+    def save_patch(self, session_id: str, patch_name: str, content: str) -> Path:
+        """Save a patch file"""
+        session_dir = self.get_session_dir(session_id)
+        patch_file = session_dir / f"{patch_name}.patch"
+        patch_file.write_text(content, encoding="utf-8")
+        logger.debug(f"Saved patch: {patch_file}")
+        return patch_file
+
+    def save_metadata(self, session_id: str, metadata: PatchMetadata) -> Path:
+        """Save metadata file"""
+        session_dir = self.get_session_dir(session_id)
+        metadata_file = session_dir / "metadata.json"
+        metadata_file.write_text(
+            json.dumps(asdict(metadata), indent=2, default=str),
+            encoding="utf-8"
+        )
+        logger.debug(f"Saved metadata: {metadata_file}")
+        return metadata_file
+
+
+class PatchTracker:
+    """
+    Tracks code generation by creating unified diffs before/after AI operations.
+
+    Usage:
+        tracker = PatchTracker(output_dir)
+        tracker.start_session(api_info)
+
+        # Before AI enhancement
+        tracker.capture_pre_llm_state(files_dict)
+
+        # ... AI enhancement happens ...
+
+        # After AI enhancement
+        tracker.capture_post_llm_state(enhanced_files_dict)
+
+        tracker.finalize_session(metadata)
+    """
+
+    def __init__(
+        self,
+        output_dir: Path,
+        storage: Optional[PatchStorageProtocol] = None
+    ):
+        self.output_dir = Path(output_dir)
+        self.storage = storage or FileSystemPatchStorage(self.output_dir)
+        self.session_id: Optional[str] = None
+        self.pre_llm_files: Dict[str, str] = {}
+        self.post_llm_files: Dict[str, str] = {}
+        self._start_time: Optional[datetime] = None
+
+    def _generate_session_id(self) -> str:
+        """Generate PostgreSQL-style timestamped session ID"""
+        return datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+    def start_session(self, api_info: Optional[Dict[str, Any]] = None) -> str:
+        """Start a new patch tracking session"""
+        self.session_id = self._generate_session_id()
+        self._start_time = datetime.now()
+        self.pre_llm_files = {}
+        self.post_llm_files = {}
+
+        logger.info(f"Started patch tracking session: {self.session_id}")
+        return self.session_id
+
+    def capture_pre_llm_state(
+        self,
+        files: Dict[str, str],
+        directory_files: Optional[List[Dict[str, str]]] = None
+    ) -> None:
+        """
+        Capture the state of generated files BEFORE AI LLM enhancement.
+
+        Args:
+            files: Main files dict (filename -> content)
+            directory_files: List of workflow file dicts
+        """
+        if not self.session_id:
+            self.start_session()
+
+        # Capture main files
+        for filename, content in files.items():
+            self.pre_llm_files[filename] = content
+
+        # Capture workflow/directory files
+        if directory_files:
+            for file_dict in directory_files:
+                for filename, content in file_dict.items():
+                    self.pre_llm_files[f"workflows/{filename}"] = content
+
+        logger.debug(f"Captured pre-LLM state: {len(self.pre_llm_files)} files")
+
+    def capture_post_llm_state(
+        self,
+        files: Dict[str, str],
+        directory_files: Optional[List[Dict[str, str]]] = None
+    ) -> None:
+        """
+        Capture the state of generated files AFTER AI LLM enhancement.
+
+        Args:
+            files: Main files dict (filename -> content)
+            directory_files: List of workflow file dicts
+        """
+        if not self.session_id:
+            raise RuntimeError("No active session. Call start_session() first.")
+
+        # Capture main files
+        for filename, content in files.items():
+            self.post_llm_files[filename] = content
+
+        # Capture workflow/directory files
+        if directory_files:
+            for file_dict in directory_files:
+                for filename, content in file_dict.items():
+                    self.post_llm_files[f"workflows/{filename}"] = content
+
+        logger.debug(f"Captured post-LLM state: {len(self.post_llm_files)} files")
+
+    def _generate_unified_diff(
+        self,
+        files_before: Dict[str, str],
+        files_after: Dict[str, str],
+        context_lines: int = 3
+    ) -> str:
+        """Generate unified diff between two file states"""
+        diff_lines = []
+
+        # Get all unique filenames
+        all_files = sorted(set(files_before.keys()) | set(files_after.keys()))
+
+        for filename in all_files:
+            before_content = files_before.get(filename, "")
+            after_content = files_after.get(filename, "")
+
+            if before_content == after_content:
+                continue  # Skip unchanged files
+
+            before_lines = before_content.splitlines(keepends=True)
+            after_lines = after_content.splitlines(keepends=True)
+
+            # Ensure lines end with newline for proper diff
+            if before_lines and not before_lines[-1].endswith('\n'):
+                before_lines[-1] += '\n'
+            if after_lines and not after_lines[-1].endswith('\n'):
+                after_lines[-1] += '\n'
+
+            diff = difflib.unified_diff(
+                before_lines,
+                after_lines,
+                fromfile=f"a/{filename}",
+                tofile=f"b/{filename}",
+                n=context_lines
+            )
+
+            diff_lines.extend(diff)
+
+        return "".join(diff_lines)
+
+    def save_patches(self) -> Dict[str, Path]:
+        """Save pre-LLM and post-LLM patches"""
+        if not self.session_id:
+            raise RuntimeError("No active session.")
+
+        saved_paths = {}
+
+        # Pre-LLM patch: diff from empty to pre-LLM state (shows template output)
+        pre_llm_diff = self._generate_unified_diff({}, self.pre_llm_files)
+        if pre_llm_diff:
+            saved_paths["pre_llm"] = self.storage.save_patch(
+                self.session_id, "pre_llm", pre_llm_diff
+            )
+
+        # Post-LLM patch: diff from pre-LLM to post-LLM (shows AI changes)
+        post_llm_diff = self._generate_unified_diff(
+            self.pre_llm_files, self.post_llm_files
+        )
+        if post_llm_diff:
+            saved_paths["post_llm"] = self.storage.save_patch(
+                self.session_id, "post_llm", post_llm_diff
+            )
+
+        return saved_paths
+
+    def finalize_session(
+        self,
+        api_info: Optional[Dict[str, Any]] = None,
+        endpoints_count: int = 0,
+        ai_model: Optional[str] = None,
+        enhancements_applied: Optional[List[str]] = None,
+        error: Optional[str] = None
+    ) -> PatchMetadata:
+        """Finalize the session and save metadata"""
+        if not self.session_id:
+            raise RuntimeError("No active session.")
+
+        # Calculate generation time
+        generation_time = 0.0
+        if self._start_time:
+            generation_time = (datetime.now() - self._start_time).total_seconds()
+
+        # Build metadata
+        metadata = PatchMetadata(
+            timestamp=self.session_id,
+            api_title=api_info.get("title", "Unknown") if api_info else "Unknown",
+            api_version=api_info.get("version", "Unknown") if api_info else "Unknown",
+            endpoints_count=endpoints_count,
+            files_generated=list(self.post_llm_files.keys() or self.pre_llm_files.keys()),
+            ai_model=ai_model,
+            enhancements_applied=enhancements_applied or [],
+            generation_time_seconds=generation_time,
+            error=error
+        )
+
+        # Save patches and metadata
+        self.save_patches()
+        self.storage.save_metadata(self.session_id, metadata)
+
+        logger.info(f"Finalized patch session: {self.session_id}")
+
+        # Reset state
+        session_id = self.session_id
+        self.session_id = None
+        self.pre_llm_files = {}
+        self.post_llm_files = {}
+        self._start_time = None
+
+        return metadata
+
+    def get_session_path(self) -> Optional[Path]:
+        """Get the current session's directory path"""
+        if not self.session_id:
+            return None
+        return self.storage.get_session_dir(self.session_id)
+
+
+class PatchTrackerContext:
+    """
+    Context manager for patch tracking.
+
+    Usage:
+        async with PatchTrackerContext(output_dir, api_info) as tracker:
+            tracker.capture_pre_llm_state(base_files, workflow_files)
+            enhanced_files = await enhance_with_ai(base_files)
+            tracker.capture_post_llm_state(enhanced_files, enhanced_workflow_files)
+    """
+
+    def __init__(
+        self,
+        output_dir: Path,
+        api_info: Optional[Dict[str, Any]] = None,
+        enabled: bool = True
+    ):
+        self.output_dir = output_dir
+        self.api_info = api_info
+        self.enabled = enabled
+        self.tracker: Optional[PatchTracker] = None
+
+    async def __aenter__(self) -> Optional[PatchTracker]:
+        if not self.enabled:
+            return None
+
+        self.tracker = PatchTracker(self.output_dir)
+        self.tracker.start_session(self.api_info)
+        return self.tracker
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self.tracker and self.tracker.session_id:
+            error_msg = str(exc_val) if exc_val else None
+            self.tracker.finalize_session(
+                api_info=self.api_info,
+                error=error_msg
+            )

--- a/src/devdox_ai_locust/utils/patch_tracker.py
+++ b/src/devdox_ai_locust/utils/patch_tracker.py
@@ -1,239 +1,269 @@
 """
 Patch Tracking System for DevDox AI Locust
 
-Tracks code generation by saving patch files before and after AI LLM operations.
-Similar to PostgreSQL's WAL (Write-Ahead Logging) concept - creates timestamped
-directories with pre/post LLM patches for analysis and comparison.
+PostgreSQL WAL-Inspired Design (v3.0)
+=====================================
 
-This module integrates with the central MetadataManager to store patch sessions
-under the organized .devdox_ai_locust/ directory structure.
+Tracks code generation milestones by creating sequential patch files.
+Each milestone (template generation, LLM enhancement, etc.) gets its own patch.
 
-Structure (v2.0):
+Structure:
     .devdox_ai_locust/
-    ├── metadata.json                          # Central metadata (MetadataManager)
-    └── ai_enhancement/
-        └── patches/
-            └── {session_id}/                  # e.g., 2025-12-28_21-47-06
-                ├── pre_llm.patch              # Template output before AI
-                ├── post_llm.patch             # Changes made by AI
-                ├── summary.json               # Patch statistics
-                └── session.json               # Session-specific metadata
+    ├── metadata.json       # Central metadata
+    ├── manifest.json       # WAL manifest - maps patches to milestones
+    └── wal/                # Sequential patches
+        ├── 000001_a1b2c3d4.patch   # template_generation
+        ├── 000002_e5f6g7h8.patch   # llm_enhancement
+        └── ...
+
+Key Concepts:
+    - Milestones are types of code changes (template_generation, llm_enhancement, etc.)
+    - Each patch is named with sequence number + short UUID
+    - manifest.json tracks what milestone each patch represents
+    - Extensible for future milestone types
 """
 
-import json
 import logging
 import difflib
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Any, Optional, List, Protocol, TYPE_CHECKING
-from pydantic import BaseModel, Field
-import asyncio
+from typing import Dict, Any, Optional, List, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .metadata_manager import MetadataManager
+    from .metadata_manager import MetadataManager, PatchEntry, PatchStats
 
 logger = logging.getLogger(__name__)
 
 
-class PatchSessionMetadata(BaseModel):
-    """Metadata for a single patch session (stored in session.json)"""
-    session_id: str
-    timestamp: str
-    api_title: str
-    api_version: str
-    endpoints_count: int
-    files_generated: List[str] = Field(default_factory=list)
-    ai_model: Optional[str] = None
-    enhancements_applied: List[str] = Field(default_factory=list)
-    generation_time_seconds: float = 0.0
-    pre_llm_files_count: int = 0
-    post_llm_files_count: int = 0
-    files_changed: int = 0
-    error: Optional[str] = None
-
-
-class PatchStorageProtocol(Protocol):
-    """Protocol for patch storage backends (allows dependency injection)"""
-
-    def save_patch(self, session_id: str, patch_name: str, content: str) -> Path:
-        """Save a patch file"""
-        ...
-
-    def save_session_metadata(self, session_id: str, metadata: PatchSessionMetadata) -> Path:
-        """Save session metadata file"""
-        ...
-
-    def get_session_dir(self, session_id: str) -> Path:
-        """Get the session directory path"""
-        ...
-
-
-class FileSystemPatchStorage:
-    """File system based patch storage"""
-
-    def __init__(self, patches_dir: Path):
-        """
-        Initialize patch storage.
-
-        Args:
-            patches_dir: The patches directory (typically .devdox_ai_locust/patches/)
-        """
-        self.patches_dir = Path(patches_dir)
-
-    def _ensure_dir(self, path: Path) -> Path:
-        """Ensure directory exists"""
-        path.mkdir(parents=True, exist_ok=True)
-        return path
-
-    def get_session_dir(self, session_id: str) -> Path:
-        """Get the session directory path"""
-        return self._ensure_dir(self.patches_dir / session_id)
-
-    def save_patch(self, session_id: str, patch_name: str, content: str) -> Path:
-        """Save a patch file"""
-        session_dir = self.get_session_dir(session_id)
-        patch_file = session_dir / f"{patch_name}.patch"
-        patch_file.write_text(content, encoding="utf-8")
-        logger.debug(f"Saved patch: {patch_file}")
-        return patch_file
-
-    def save_session_metadata(self, session_id: str, metadata: PatchSessionMetadata) -> Path:
-        """Save session-specific metadata file (session.json)"""
-        session_dir = self.get_session_dir(session_id)
-        session_file = session_dir / "session.json"
-        session_file.write_text(
-            json.dumps(metadata.model_dump(), indent=2, default=str),
-            encoding="utf-8"
-        )
-        logger.debug(f"Saved session metadata: {session_file}")
-        return session_file
-
-
 class PatchTracker:
     """
-    Tracks code generation by creating unified diffs before/after AI operations.
+    Tracks code generation milestones by creating sequential patches.
 
-    Integrates with MetadataManager to store patches under .devdox_ai_locust/patches/
-    and register sessions with the central metadata.
+    Integrates with MetadataManager to store patches in the WAL directory.
+    Each milestone (template generation, LLM enhancement, etc.) creates a patch.
 
     Usage:
-        # Standalone usage (creates its own patches directory)
-        tracker = PatchTracker(output_dir)
-        tracker.start_session(api_info)
-
-        # Or integrated with MetadataManager
         metadata_manager = MetadataManager(output_dir)
+        metadata_manager.initialize_session(api_info)
+
         tracker = PatchTracker.from_metadata_manager(metadata_manager)
-        tracker.start_session(api_info)
 
-        # Before AI enhancement
-        tracker.capture_pre_llm_state(files_dict)
-
-        # ... AI enhancement happens ...
+        # After template generation
+        tracker.capture_template_state(files_dict)
 
         # After AI enhancement
-        tracker.capture_post_llm_state(enhanced_files_dict)
+        tracker.capture_enhanced_state(enhanced_files_dict)
 
-        tracker.finalize_session(metadata)
+        # Finalize
+        tracker.finalize()
     """
 
     def __init__(
         self,
         output_dir: Path,
-        storage: Optional[PatchStorageProtocol] = None,
         metadata_manager: Optional["MetadataManager"] = None
     ):
+        """
+        Initialize patch tracker.
+
+        Args:
+            output_dir: Base output directory
+            metadata_manager: MetadataManager instance (recommended)
+        """
         self.output_dir = Path(output_dir)
         self.metadata_manager = metadata_manager
 
-        # Determine patches directory
-        if metadata_manager:
-            patches_dir = metadata_manager.patches_dir
-        else:
-            patches_dir = self.output_dir / ".devdox_ai_locust" / "patches"
-            patches_dir.mkdir(parents=True, exist_ok=True)
-
-        self.storage = storage or FileSystemPatchStorage(patches_dir)
-        self.session_id: Optional[str] = None
-        self.pre_llm_files: Dict[str, str] = {}
-        self.post_llm_files: Dict[str, str] = {}
+        # State tracking
+        self.template_files: Dict[str, str] = {}
+        self.enhanced_files: Dict[str, str] = {}
         self._start_time: Optional[datetime] = None
+        self._session_started = False
 
     @classmethod
     def from_metadata_manager(cls, metadata_manager: "MetadataManager") -> "PatchTracker":
-        """Create a PatchTracker integrated with a MetadataManager"""
+        """Create a PatchTracker integrated with a MetadataManager."""
         return cls(
             output_dir=metadata_manager.output_dir,
             metadata_manager=metadata_manager
         )
 
-    def _generate_session_id(self) -> str:
-        """Generate PostgreSQL-style timestamped session ID"""
-        return datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-
-    def start_session(self, api_info: Optional[Dict[str, Any]] = None) -> str:
-        """Start a new patch tracking session"""
-        self.session_id = self._generate_session_id()
+    def start_session(self) -> None:
+        """Start tracking a new session."""
         self._start_time = datetime.now()
-        self.pre_llm_files = {}
-        self.post_llm_files = {}
+        self.template_files = {}
+        self.enhanced_files = {}
+        self._session_started = True
+        logger.debug("Started patch tracking session")
 
-        logger.info(f"Started patch tracking session: {self.session_id}")
-        return self.session_id
-
-    def capture_pre_llm_state(
+    def capture_template_state(
         self,
         files: Dict[str, str],
-        directory_files: Optional[List[Dict[str, str]]] = None
-    ) -> None:
+        workflow_files: Optional[List[Dict[str, str]]] = None
+    ) -> Optional["PatchEntry"]:
         """
-        Capture the state of generated files BEFORE AI LLM enhancement.
+        Capture files after template generation (before AI enhancement).
+
+        Creates a template_generation milestone patch.
 
         Args:
             files: Main files dict (filename -> content)
-            directory_files: List of workflow file dicts
+            workflow_files: List of workflow file dicts
+
+        Returns:
+            PatchEntry if patch was created
         """
-        if not self.session_id:
+        if not self._session_started:
             self.start_session()
 
         # Capture main files
         for filename, content in files.items():
-            self.pre_llm_files[filename] = content
+            self.template_files[filename] = content
 
         # Capture workflow/directory files
-        if directory_files:
-            for file_dict in directory_files:
+        if workflow_files:
+            for file_dict in workflow_files:
                 for filename, content in file_dict.items():
-                    self.pre_llm_files[f"workflows/{filename}"] = content
+                    self.template_files[f"workflows/{filename}"] = content
 
-        logger.debug(f"Captured pre-LLM state: {len(self.pre_llm_files)} files")
+        logger.debug(f"Captured template state: {len(self.template_files)} files")
 
-    def capture_post_llm_state(
+        # Create the template generation patch
+        return self._create_milestone_patch(
+            milestone="template_generation",
+            files_before={},
+            files_after=self.template_files,
+            description="Initial template-based generation",
+        )
+
+    def capture_enhanced_state(
         self,
         files: Dict[str, str],
-        directory_files: Optional[List[Dict[str, str]]] = None
-    ) -> None:
+        workflow_files: Optional[List[Dict[str, str]]] = None,
+        ai_model: Optional[str] = None,
+    ) -> Optional["PatchEntry"]:
         """
-        Capture the state of generated files AFTER AI LLM enhancement.
+        Capture files after AI enhancement.
+
+        Creates an llm_enhancement milestone patch showing the diff.
 
         Args:
-            files: Main files dict (filename -> content)
-            directory_files: List of workflow file dicts
+            files: Enhanced files dict (filename -> content)
+            workflow_files: List of workflow file dicts
+            ai_model: Name of the AI model used
+
+        Returns:
+            PatchEntry if patch was created
         """
-        if not self.session_id:
+        if not self._session_started:
             raise RuntimeError("No active session. Call start_session() first.")
 
         # Capture main files
         for filename, content in files.items():
-            self.post_llm_files[filename] = content
+            self.enhanced_files[filename] = content
 
         # Capture workflow/directory files
-        if directory_files:
-            for file_dict in directory_files:
+        if workflow_files:
+            for file_dict in workflow_files:
                 for filename, content in file_dict.items():
-                    self.post_llm_files[f"workflows/{filename}"] = content
+                    self.enhanced_files[f"workflows/{filename}"] = content
 
-        logger.debug(f"Captured post-LLM state: {len(self.post_llm_files)} files")
+        logger.debug(f"Captured enhanced state: {len(self.enhanced_files)} files")
+
+        # Create the LLM enhancement patch
+        metadata = {}
+        if ai_model:
+            metadata["ai_model"] = ai_model
+
+        return self._create_milestone_patch(
+            milestone="llm_enhancement",
+            files_before=self.template_files,
+            files_after=self.enhanced_files,
+            description="AI enhancement of test files",
+            extra_metadata=metadata,
+        )
+
+    def capture_validation_state(
+        self,
+        files: Dict[str, str],
+        validation_results: Optional[Dict[str, Any]] = None,
+    ) -> Optional["PatchEntry"]:
+        """
+        Capture files after validation/fixes.
+
+        Creates a validation milestone patch.
+
+        Args:
+            files: Files after validation
+            validation_results: Optional validation metadata
+
+        Returns:
+            PatchEntry if patch was created
+        """
+        if not self._session_started:
+            raise RuntimeError("No active session.")
+
+        # Get the previous state (enhanced or template)
+        previous = self.enhanced_files if self.enhanced_files else self.template_files
+
+        metadata = {}
+        if validation_results:
+            metadata["validation"] = validation_results
+
+        return self._create_milestone_patch(
+            milestone="validation",
+            files_before=previous,
+            files_after=files,
+            description="Validation and fixes",
+            extra_metadata=metadata,
+        )
+
+    def _create_milestone_patch(
+        self,
+        milestone: str,
+        files_before: Dict[str, str],
+        files_after: Dict[str, str],
+        description: str = "",
+        extra_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional["PatchEntry"]:
+        """
+        Create a patch for a milestone.
+
+        Args:
+            milestone: Type of milestone
+            files_before: Files before this milestone
+            files_after: Files after this milestone
+            description: Human-readable description
+            extra_metadata: Additional metadata
+
+        Returns:
+            PatchEntry if patch was created, None if no changes
+        """
+        if not self.metadata_manager:
+            logger.warning("No metadata manager - patch not saved")
+            return None
+
+        # Generate unified diff
+        diff_content = self._generate_unified_diff(files_before, files_after)
+
+        if not diff_content.strip():
+            logger.debug(f"No changes for milestone: {milestone}")
+            return None
+
+        # Calculate stats
+        from .metadata_manager import PatchStats
+        stats = self._calculate_stats(files_before, files_after)
+
+        # Create the patch
+        entry = self.metadata_manager.create_patch(
+            milestone=milestone,
+            content=diff_content,
+            description=description,
+            stats=stats,
+            metadata=extra_metadata,
+        )
+
+        logger.info(f"Created patch {entry.id} for milestone: {milestone}")
+        return entry
 
     def _generate_unified_diff(
         self,
@@ -241,7 +271,7 @@ class PatchTracker:
         files_after: Dict[str, str],
         context_lines: int = 3
     ) -> str:
-        """Generate unified diff between two file states"""
+        """Generate unified diff between two file states."""
         diff_lines = []
 
         # Get all unique filenames
@@ -275,103 +305,73 @@ class PatchTracker:
 
         return "".join(diff_lines)
 
-    def save_patches(self) -> Dict[str, Path]:
-        """Save pre-LLM and post-LLM patches"""
-        if not self.session_id:
-            raise RuntimeError("No active session.")
-
-        saved_paths = {}
-
-        # Pre-LLM patch: diff from empty to pre-LLM state (shows template output)
-        pre_llm_diff = self._generate_unified_diff({}, self.pre_llm_files)
-        if pre_llm_diff:
-            saved_paths["pre_llm"] = self.storage.save_patch(
-                self.session_id, "pre_llm", pre_llm_diff
-            )
-
-        # Post-LLM patch: diff from pre-LLM to post-LLM (shows AI changes)
-        post_llm_diff = self._generate_unified_diff(
-            self.pre_llm_files, self.post_llm_files
-        )
-        if post_llm_diff:
-            saved_paths["post_llm"] = self.storage.save_patch(
-                self.session_id, "post_llm", post_llm_diff
-            )
-
-        return saved_paths
-
-    def finalize_session(
+    def _calculate_stats(
         self,
-        api_info: Optional[Dict[str, Any]] = None,
-        endpoints_count: int = 0,
-        ai_model: Optional[str] = None,
-        enhancements_applied: Optional[List[str]] = None,
-        error: Optional[str] = None
-    ) -> PatchSessionMetadata:
-        """Finalize the session and save metadata"""
-        if not self.session_id:
-            raise RuntimeError("No active session.")
+        files_before: Dict[str, str],
+        files_after: Dict[str, str],
+    ) -> "PatchStats":
+        """Calculate patch statistics."""
+        from .metadata_manager import PatchStats
 
-        # Calculate generation time
-        generation_time = 0.0
-        if self._start_time:
-            generation_time = (datetime.now() - self._start_time).total_seconds()
+        files_changed = 0
+        additions = 0
+        deletions = 0
 
-        # Calculate files changed
-        files_changed = self._count_changed_files()
+        all_files = set(files_before.keys()) | set(files_after.keys())
 
-        # Build session metadata
-        metadata = PatchSessionMetadata(
-            session_id=self.session_id,
-            timestamp=datetime.now().isoformat(),
-            api_title=api_info.get("title", "Unknown") if api_info else "Unknown",
-            api_version=api_info.get("version", "Unknown") if api_info else "Unknown",
-            endpoints_count=endpoints_count,
-            files_generated=list(self.post_llm_files.keys() or self.pre_llm_files.keys()),
-            ai_model=ai_model,
-            enhancements_applied=enhancements_applied or [],
-            generation_time_seconds=generation_time,
-            pre_llm_files_count=len(self.pre_llm_files),
-            post_llm_files_count=len(self.post_llm_files),
+        for filename in all_files:
+            before = files_before.get(filename, "")
+            after = files_after.get(filename, "")
+
+            if before != after:
+                files_changed += 1
+
+                before_lines = set(before.splitlines())
+                after_lines = set(after.splitlines())
+
+                additions += len(after_lines - before_lines)
+                deletions += len(before_lines - after_lines)
+
+        return PatchStats(
             files_changed=files_changed,
-            error=error
+            additions=additions,
+            deletions=deletions,
         )
 
-        # Save patches and session metadata
-        self.save_patches()
-        self.storage.save_session_metadata(self.session_id, metadata)
+    def finalize(self) -> None:
+        """
+        Finalize the tracking session.
 
-        # Register with central metadata manager if available
-        if self.metadata_manager:
-            self.metadata_manager.register_patch_session(self.session_id)
-
-        logger.info(f"Finalized patch session: {self.session_id}")
-
+        Note: Does NOT call metadata_manager.finalize_session().
+        The caller should finalize the metadata manager separately.
+        """
         # Reset state
-        session_id = self.session_id
-        self.session_id = None
-        self.pre_llm_files = {}
-        self.post_llm_files = {}
+        self.template_files = {}
+        self.enhanced_files = {}
         self._start_time = None
+        self._session_started = False
 
-        return metadata
+        logger.info("Finalized patch tracking session")
 
-    def _count_changed_files(self) -> int:
-        """Count number of files that were changed by LLM"""
-        changed = 0
-        all_files = set(self.pre_llm_files.keys()) | set(self.post_llm_files.keys())
-        for filename in all_files:
-            before = self.pre_llm_files.get(filename, "")
-            after = self.post_llm_files.get(filename, "")
-            if before != after:
-                changed += 1
-        return changed
+    def get_summary(self) -> Dict[str, Any]:
+        """Get a summary of the current session."""
+        if not self.metadata_manager:
+            return {"patches": 0}
 
-    def get_session_path(self) -> Optional[Path]:
-        """Get the current session's directory path"""
-        if not self.session_id:
-            return None
-        return self.storage.get_session_dir(self.session_id)
+        manifest = self.metadata_manager.manifest
+        patches_by_milestone = {}
+
+        for patch in manifest.patches:
+            milestone = patch.milestone
+            if milestone not in patches_by_milestone:
+                patches_by_milestone[milestone] = []
+            patches_by_milestone[milestone].append(patch.id)
+
+        return {
+            "session_id": manifest.session_id,
+            "total_patches": len(manifest.patches),
+            "patches_by_milestone": patches_by_milestone,
+        }
 
 
 class PatchTrackerContext:
@@ -379,47 +379,50 @@ class PatchTrackerContext:
     Context manager for patch tracking.
 
     Usage:
-        # Standalone usage
-        async with PatchTrackerContext(output_dir, api_info) as tracker:
-            tracker.capture_pre_llm_state(base_files, workflow_files)
-            enhanced_files = await enhance_with_ai(base_files)
-            tracker.capture_post_llm_state(enhanced_files, enhanced_workflow_files)
-
-        # With MetadataManager integration
         metadata_manager = MetadataManager(output_dir)
-        async with PatchTrackerContext(output_dir, api_info, metadata_manager=metadata_manager) as tracker:
-            ...
+        metadata_manager.initialize_session(api_info)
+
+        async with PatchTrackerContext(metadata_manager) as tracker:
+            tracker.capture_template_state(base_files, workflow_files)
+            enhanced_files = await enhance_with_ai(base_files)
+            tracker.capture_enhanced_state(enhanced_files)
     """
 
     def __init__(
         self,
-        output_dir: Path,
-        api_info: Optional[Dict[str, Any]] = None,
+        metadata_manager: "MetadataManager",
         enabled: bool = True,
-        metadata_manager: Optional["MetadataManager"] = None
     ):
-        self.output_dir = output_dir
-        self.api_info = api_info
-        self.enabled = enabled
+        """
+        Initialize context.
+
+        Args:
+            metadata_manager: MetadataManager instance
+            enabled: Whether tracking is enabled
+        """
         self.metadata_manager = metadata_manager
+        self.enabled = enabled
         self.tracker: Optional[PatchTracker] = None
 
     async def __aenter__(self) -> Optional[PatchTracker]:
         if not self.enabled:
             return None
 
-        if self.metadata_manager:
-            self.tracker = PatchTracker.from_metadata_manager(self.metadata_manager)
-        else:
-            self.tracker = PatchTracker(self.output_dir)
-
-        self.tracker.start_session(self.api_info)
+        self.tracker = PatchTracker.from_metadata_manager(self.metadata_manager)
+        self.tracker.start_session()
         return self.tracker
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        if self.tracker and self.tracker.session_id:
-            error_msg = str(exc_val) if exc_val else None
-            self.tracker.finalize_session(
-                api_info=self.api_info,
-                error=error_msg
-            )
+        if self.tracker and self.tracker._session_started:
+            self.tracker.finalize()
+
+
+# Backwards compatibility aliases
+def capture_pre_llm_state(tracker: PatchTracker, files: Dict[str, str], workflow_files=None):
+    """Backwards compatible wrapper for capture_template_state."""
+    return tracker.capture_template_state(files, workflow_files)
+
+
+def capture_post_llm_state(tracker: PatchTracker, files: Dict[str, str], workflow_files=None):
+    """Backwards compatible wrapper for capture_enhanced_state."""
+    return tracker.capture_enhanced_state(files, workflow_files)


### PR DESCRIPTION
# Add patch tracking system and fix AI code duplication

Patch Tracking System:
- Add new PatchTracker class for capturing pre/post LLM code generation
- Creates .devdox_ai_locust/patches/ directory with timestamped sessions
- Each session contains pre_llm.patch, post_llm.patch, and metadata.json
- Follows PostgreSQL WAL-style timestamped directory naming
- Decoupled design using Protocol for dependency injection
- Integrated into CLI generate command

AI Enhancement Fix:
- Add _remove_duplicate_class_definitions() to clean AI responses
- Prevents AI from appending unrelated classes (TestDataGenerator, LoadTestConfig, etc.) to workflow files
- Fixes issue where authentication_workflow.py had duplicate class definitions

Closes issue with faulty generated workflow imports.

---

# Add central metadata manager for .devdox_ai_locust/ directory

- Create MetadataManager class to manage central metadata.json file
- Metadata tracks API info, generation config, output files, and features
- Update PatchTracker to integrate with MetadataManager
- Patch sessions now stored in .devdox_ai_locust/patches/ subdirectory
- Session-specific data stored in session.json instead of metadata.json
- CLI updated to use MetadataManager as central tracking system
- Extensible design allows future features to add their own sections

---

# Reorganize .devdox_ai_locust/ directory structure (v2.0)

---

# Add verbose progress display and migrate to Pydantic models

Progress Display:
- Add ProgressPhase enum and ProgressStatus model for tracking
- Create ProgressDisplay class in CLI with Rich live progress bar
- Add progress callbacks to HybridLocustGenerator
- Report progress for each AI enhancement phase
- Show percentage completion and current operation

Pydantic Migration (from dataclasses):
- hybrid_loctus_generator.py: AIEnhancementConfig, EnhancementResult, ErrorClassification, ProtectedSymbol
- metadata_manager.py: CentralMetadata, APIMetadata, GenerationMetadata, OutputMetadata, PatchSessionInfo, AIEnhancementMetadata, etc.
- patch_tracker.py: PatchSessionMetadata
- open_ai_parser.py: Parameter, RequestBody, Response, Endpoint

Now users see real-time progress during generate:
- Generating base templates
- Analyzing codebase dependencies
- Enhancing locustfile (AI)
- Enhancing test data (AI)
- Enhancing validation (AI)
- Generating domain flows (AI)
- Enhancing workflows (AI)
- Validating output

---

# Simplify .devdox_ai_locust with PostgreSQL WAL-inspired design (v3.0)

Redesigned the internal patch tracking structure for simplicity and extensibility:

- Flat directory structure: metadata.json, manifest.json, and wal/ directory
- Sequential UUID-named patches (e.g., 000001_a1b2c3d4.patch)
- Milestone-based tracking (template_generation, llm_enhancement, etc.)
- Extensible for future milestone types (validation, user_edit, refactor)

New structure:
  .devdox_ai_locust/
  ├── metadata.json       # Central metadata (API info, config)
  ├── manifest.json       # WAL manifest - maps patches to milestones
  └── wal/                # Write-Ahead Log - sequential patches

This removes the complex nested directory structure and makes the system
more intuitive and easier to extend with new milestone types.


---

# Fix structure to use datetime directories with .patches and session.json

Corrected structure per user feedback:
  .devdox_ai_locust/
  ├── metadata.json                    # Central metadata
  └── {session_id}/                    # e.g., 2025-12-29_10-39-24
      ├── session.json                 # Session milestones info
      └── .patches/                    # Sequential patch files
          ├── 000001_a1b2c3d4.patch
          └── 000002_e5f6g7h8.patch

- Keeps datetime-stamped session directories
- .patches directory inside each session
- session.json tracks milestones (template_generation, llm_enhancement, etc.)
- Sequential UUID-named patch files

---

# Improve output metadata with file tree structure and stats

Changed output section in metadata.json from flat file list to:
- Tree structure with paths as keys (e.g., "workflows/base.py")
- File metadata: category, size_bytes, lines, description
- Summary: total_files, total_bytes, by_category breakdown
- Categories: main, workflow, config, docs

New structure:
  "output": {
    "root": "locust_tests",
    "files": {
      "locustfile.py": {"category": "main", "size_bytes": 1234, "lines": 50},
      "workflows/base.py": {"category": "workflow", ...}
    },
    "summary": {"total_files": 14, "total_bytes": 15000, "by_category": {...}}
  }

---

# Simplify file tree in metadata.json

Renamed 'output' to 'files' - a simple tree tracking generated test suite files.
Each file has only: size (bytes) and lines count.

Structure:
  "files": {
    "locustfile.py": {"size": 1234, "lines": 50},
    "workflows/base_workflow.py": {"size": 800, "lines": 45}
  }

